### PR TITLE
Restore production docs authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ npm run check
 npm run dev
 ```
 
-The rendered site fails closed unless both `DOCS_USER` and `DOCS_PASSWORD` are configured.
+The rendered site fails closed unless `DOCS_PASSWORD` is configured. `DOCS_USER`
+is optional and defaults to `gui`, preserving the production credential contract.
 
 ## Documentation changes
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -21,10 +21,12 @@ function unauthorized() {
 }
 
 export function proxy(req: NextRequest) {
-  const expectedUser = process.env.DOCS_USER
+  // Preserve the established production contract: deployments may configure
+  // only DOCS_PASSWORD, in which case the username remains "gui".
+  const expectedUser = process.env.DOCS_USER || 'gui'
   const expectedPass = process.env.DOCS_PASSWORD
 
-  if (!expectedUser || !expectedPass) {
+  if (!expectedPass) {
     return new NextResponse('Site auth not configured.', {
       status: 503,
       headers: { 'Cache-Control': 'private, no-store, max-age=0' },

--- a/scripts/smoke-site.mjs
+++ b/scripts/smoke-site.mjs
@@ -3,10 +3,10 @@ import { legacyRedirects } from '../config/legacy-redirects.mjs'
 
 const port = 3219
 const baseUrl = `http://127.0.0.1:${port}`
-const validAuth = `Basic ${Buffer.from('smoke:local-smoke-password').toString('base64')}`
+const validAuth = `Basic ${Buffer.from('gui:local-smoke-password').toString('base64')}`
 const wrongAuth = `Basic ${Buffer.from('wrong:wrong').toString('base64')}`
 const server = spawn(process.execPath, ['node_modules/next/dist/bin/next', 'start'], {
-  env: { ...process.env, PORT: String(port), DOCS_USER: 'smoke', DOCS_PASSWORD: 'local-smoke-password' },
+  env: { ...process.env, PORT: String(port), DOCS_USER: '', DOCS_PASSWORD: 'local-smoke-password' },
   stdio: ['ignore', 'pipe', 'pipe'],
 })
 


### PR DESCRIPTION
## Summary
- preserve the established `DOCS_PASSWORD`-only production contract
- default `DOCS_USER` to `gui` while continuing to fail closed without a password
- cover the default username in the production smoke test and README

## Verification
- `npm run check`
- `npm run build`
- `npm run smoke`

## Production evidence
The first post-merge deployment returned `503` on protected routes because production has `DOCS_PASSWORD` but no explicit `DOCS_USER`. Public search, robots, and sitemap assets remained healthy. This hotfix restores the previous username default without weakening the password requirement.

Related to #1.