### PR TITLE
Replace password gate with allowlisted Google sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ npm run dev
 
 The rendered site uses Google OAuth through Auth.js and fails closed unless all
 of `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `AUTH_SECRET`, and
-`AUTHORIZED_GOOGLE_EMAIL` are configured. The sign-in callback accepts only a
-Google-verified email that exactly matches `AUTHORIZED_GOOGLE_EMAIL`; the proxy
-rechecks the session email on every protected request.
+`AUTHORIZED_GOOGLE_EMAILS` are configured. The sign-in callback accepts only a
+Google-verified email that exactly matches one of the comma-separated addresses
+in `AUTHORIZED_GOOGLE_EMAILS`; the proxy rechecks the session email on every
+protected request. Store the addresses only in managed environment configuration,
+not in this public repository.
 
 ## Documentation changes
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ npm run check
 npm run dev
 ```
 
-The rendered site fails closed unless `DOCS_PASSWORD` is configured. `DOCS_USER`
-is optional and defaults to `gui`, preserving the production credential contract.
+The rendered site uses Google OAuth through Auth.js and fails closed unless all
+of `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `AUTH_SECRET`, and
+`AUTHORIZED_GOOGLE_EMAIL` are configured. The sign-in callback accepts only a
+Google-verified email that exactly matches `AUTHORIZED_GOOGLE_EMAIL`; the proxy
+rechecks the session email on every protected request.
 
 ## Documentation changes
 
@@ -36,4 +39,4 @@ is optional and defaults to `gui`, preserving the production credential contract
 
 ## Publication boundary
 
-The source repository is public. Keep the current tree sanitized even though rendered routes on Vercel also require basic authentication. The client-side search index remains public so its browser worker can load reliably. CI checks catch common publication mistakes and secrets, but human review owns the final decision. Legacy history predates these controls and is explicitly tracked for remediation in [GitHub issue #4](https://github.com/GuillaumeRacine/superagents/issues/4).
+The source repository is public. Keep the current tree sanitized even though rendered routes on Vercel also require an allowlisted Google session. The client-side search index remains public so its browser worker can load reliably. CI checks catch common publication mistakes and secrets, but human review owns the final decision. Legacy history predates these controls and is explicitly tracked for remediation in [GitHub issue #4](https://github.com/GuillaumeRacine/superagents/issues/4).

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from '@/auth'
+
+export const { GET, POST } = handlers

--- a/app/estate/data-sources/page.mdx
+++ b/app/estate/data-sources/page.mdx
@@ -9,7 +9,7 @@
 | GitHub | Code and shipped documentation | live-scanned | 147 accessible repositories across 4 owners or organizations; 139 trees scanned |
 | Context control plane | Automation registry and evidence | live-local | Generated inventory, contracts, and fleet evidence |
 | Knowledge vault | Curated context and durable knowledge | live-local | Private Git-backed vault; content remains private |
-| Hermes state | Profiles, schedules, skills, and delivery state | live-local | 81 jobs; 60 enabled; 21 paused |
+| Hermes state | Profiles, schedules, skills, and delivery state | live-local | 82 jobs; 61 enabled; 21 paused |
 | Google Drive | Default file and data store | policy-declared · not live-listed | Connector/API or web is authoritative; Drive Desktop and rclone are unavailable on this host |
 | iCloud | Apple-native data | host-visible | 18 top-level host-visible directories; content not enumerated |
 | 1Password | Credentials | policy-declared · intentionally not enumerated | Only references and access contracts may be documented |

--- a/app/governance/documentation/page.mdx
+++ b/app/governance/documentation/page.mdx
@@ -1,6 +1,6 @@
 # Documentation Governance
 
-This portal is a public-source, sanitized map with a second rendered-site access gate. Basic authentication on the website does **not** make the repository content confidential. The client-side search index and machine-navigation files are also public assets because browser workers and crawlers cannot reliably reuse HTTP Basic credentials. Robots are instructed not to index the site.
+This portal is a public-source, sanitized map with a second rendered-site access gate. Google authentication on the website does **not** make the repository content confidential. Auth.js accepts only the exact allowlisted, Google-verified email and the route proxy rechecks that email on every protected request. The client-side search index and machine-navigation files remain public assets because they mirror the sanitized source. Robots are instructed not to index the site.
 
 The current-tree publication scan does not sanitize prior commits. Legacy history is a known hardening gap tracked in [GitHub issue #4](https://github.com/GuillaumeRacine/superagents/issues/4) and must not be described as private or clean until that work is complete.
 

--- a/app/governance/documentation/page.mdx
+++ b/app/governance/documentation/page.mdx
@@ -1,6 +1,6 @@
 # Documentation Governance
 
-This portal is a public-source, sanitized map with a second rendered-site access gate. Google authentication on the website does **not** make the repository content confidential. Auth.js accepts only the exact allowlisted, Google-verified email and the route proxy rechecks that email on every protected request. The client-side search index and machine-navigation files remain public assets because they mirror the sanitized source. Robots are instructed not to index the site.
+This portal is a public-source, sanitized map with a second rendered-site access gate. Google authentication on the website does **not** make the repository content confidential. Auth.js accepts only exact allowlisted, Google-verified email addresses and the route proxy rechecks the session email on every protected request. Domain-wide access is not supported. The client-side search index and machine-navigation files remain public assets because they mirror the sanitized source. Robots are instructed not to index the site.
 
 The current-tree publication scan does not sanitize prior commits. Legacy history is a known hardening gap tracked in [GitHub issue #4](https://github.com/GuillaumeRacine/superagents/issues/4) and must not be described as private or clean until that work is complete.
 

--- a/app/reference/capability-inventory/page.mdx
+++ b/app/reference/capability-inventory/page.mdx
@@ -2,7 +2,7 @@
 
 > Generated from `config/capability-inventory.json`. Do not edit this page directly.
 
-**Snapshot:** 2026-09-08T21:53:45-04:00
+**Snapshot:** 2026-09-09T11:07:29-04:00
 
 **Scope:** Complete at the sanitized capability-group level. Private agent names, job names, personal schedules, and machine paths remain in their owning private inventories.
 
@@ -18,7 +18,7 @@ This is the complete **sanitized** capability map. Exact private agent and job c
 | [Claude standalone skills](#claude-standalone-skills) | Claude Code | 26 | item | active |
 | [Claude plugins](#claude-plugins) | Claude Code | 13 | item | 13 registered; 12 enabled |
 | [Hermes profiles](#hermes-profiles) | Hermes | 6 | item | active |
-| [Hermes scheduled jobs](#hermes-scheduled-jobs) | Hermes | 81 | grouped-private | 60 enabled; 21 paused |
+| [Hermes scheduled jobs](#hermes-scheduled-jobs) | Hermes | 82 | grouped-private | 61 enabled; 21 paused |
 | [Hermes active skills](#hermes-active-skills) | Hermes | 105 | grouped-private | active skill root |
 | [Companion and compatibility capabilities](#companion-and-compatibility-capabilities) | Gemini, Grok, OpenClaw, and OpenCode | 19 | grouped | companions installed; compatibility runtimes absent |
 
@@ -273,9 +273,9 @@ This is the complete **sanitized** capability map. Exact private agent and job c
 
 **Runtime:** Hermes
 
-**State:** 60 enabled; 21 paused
+**State:** 61 enabled; 21 paused
 
-**Published count:** 81
+**Published count:** 82
 
 **Detail level:** grouped-private
 

--- a/app/reference/system-registry/page.mdx
+++ b/app/reference/system-registry/page.mdx
@@ -234,9 +234,9 @@ This registry is a **derived index**, not a replacement for each runtime's sourc
 | Source of truth | This GitHub repository; runtime truth remains with each owning system |
 | Measurement | Pinned package lock, generated registry checks, production build, access matrix, search index, responsive browser review, and deployment evidence. |
 | Trigger | Reviewed documentation change merged to the deploy branch |
-| Permissions | Public source content must remain sanitized; rendered routes require a Google-verified session whose email exactly matches the server-side allowlist |
+| Permissions | Public source content must remain sanitized; rendered routes require a Google-verified session whose email exactly matches one of the server-side allowlist entries; domain-wide access is rejected |
 | Inputs | Reviewed registry snapshot, authoritative runbooks, official product docs, and bar-raiser findings |
 | Outputs | Searchable Nextra site, source map, operating guides, and dated system snapshot |
 | Proof | CI checks, dependency audit, production deployment, anonymous redirect and OAuth-provider checks, allowlist rejection, authenticated route checks, and issue closeout |
-| Recovery | Clone the repository, use the pinned Node version, regenerate the registry page, run checks and build, restore the Google OAuth client and exact-email allowlist from managed secrets, then redeploy |
+| Recovery | Clone the repository, use the pinned Node version, regenerate the registry page, run checks and build, restore the Google OAuth client and exact-address allowlist from managed secrets, then redeploy |
 | Snapshot counts | No volatile count published |

--- a/app/reference/system-registry/page.mdx
+++ b/app/reference/system-registry/page.mdx
@@ -2,7 +2,7 @@
 
 > Generated from `config/system-registry.json`. Do not edit this page directly.
 
-**Snapshot:** 2026-09-08T21:53:45-04:00
+**Snapshot:** 2026-09-09T11:07:29-04:00
 
 **Scope:** Sanitized architecture and operating metadata only; no credentials, personal context, private URLs, or customer data.
 
@@ -19,7 +19,7 @@ This registry is a **derived index**, not a replacement for each runtime's sourc
 | [Gemini CLI](/runtimes/companions) | companion interactive runtime | installed · bounded companion surface | 2026-09-08 |
 | [Grok CLI](/runtimes/companions) | companion interactive runtime | installed · bounded companion surface | 2026-09-08 |
 | [Compatibility assets](/runtimes/companions) | inactive interoperability files | compatibility-only · no active OpenClaw or OpenCode binary | 2026-09-08 |
-| [Super Agents documentation portal](/reference/canonical-sources) | derived documentation and navigation | active · sanitized derived index | 2026-09-08 |
+| [Super Agents documentation portal](/reference/canonical-sources) | derived documentation and navigation | active · sanitized derived index | 2026-09-09 |
 
 ## Codex
 
@@ -47,7 +47,7 @@ This registry is a **derived index**, not a replacement for each runtime's sourc
 
 **Status:** active · specialist catalog and plugin surface
 
-**Version:** 2.1.265
+**Version:** 2.1.266
 
 **Owner:** Gui
 
@@ -85,7 +85,7 @@ This registry is a **derived index**, not a replacement for each runtime's sourc
 | Outputs | Slack, Telegram, or Discord replies; local artifacts; monitored workflow results |
 | Proof | Scheduler output plus independent evidence contracts and the Context fleet scoreboard |
 | Recovery | Restore the private Hermes home repository and secrets from 1Password, install the public runtime fork, restore launch services, then run gateway and delivery checks |
-| Snapshot counts | Profiles: 6; Scheduled Jobs: 81; Enabled Jobs: 60; Paused Jobs: 21; Active User Skill Manifests: 105 |
+| Snapshot counts | Profiles: 6; Scheduled Jobs: 82; Enabled Jobs: 61; Paused Jobs: 21; Active User Skill Manifests: 105 |
 
 ## Context control plane
 
@@ -227,16 +227,16 @@ This registry is a **derived index**, not a replacement for each runtime's sourc
 
 **Owner:** Gui
 
-**Last verified:** 2026-09-08
+**Last verified:** 2026-09-09
 
 | Contract | Value |
 |---|---|
 | Source of truth | This GitHub repository; runtime truth remains with each owning system |
 | Measurement | Pinned package lock, generated registry checks, production build, access matrix, search index, responsive browser review, and deployment evidence. |
 | Trigger | Reviewed documentation change merged to the deploy branch |
-| Permissions | Public source content must remain sanitized; rendered site also requires configured access credentials |
+| Permissions | Public source content must remain sanitized; rendered routes require a Google-verified session whose email exactly matches the server-side allowlist |
 | Inputs | Reviewed registry snapshot, authoritative runbooks, official product docs, and bar-raiser findings |
 | Outputs | Searchable Nextra site, source map, operating guides, and dated system snapshot |
-| Proof | CI checks, dependency audit, production deployment, unauthenticated/authenticated route checks, and issue closeout |
-| Recovery | Clone the repository, use the pinned Node version, regenerate the registry page, run checks and build, then redeploy with access variables |
+| Proof | CI checks, dependency audit, production deployment, anonymous redirect and OAuth-provider checks, allowlist rejection, authenticated route checks, and issue closeout |
+| Recovery | Clone the repository, use the pinned Node version, regenerate the registry page, run checks and build, restore the Google OAuth client and exact-email allowlist from managed secrets, then redeploy |
 | Snapshot counts | No volatile count published |

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,21 @@
+import NextAuth from 'next-auth'
+import Google from 'next-auth/providers/google'
+import { isAllowedEmail } from '@/lib/access-policy.mjs'
+
+export const { handlers, auth } = NextAuth({
+  providers: [
+    Google({
+      authorization: { params: { prompt: 'select_account' } },
+    }),
+  ],
+  session: {
+    strategy: 'jwt',
+    maxAge: 12 * 60 * 60,
+  },
+  callbacks: {
+    async signIn({ account, profile }) {
+      if (account?.provider !== 'google') return false
+      return profile?.email_verified === true && isAllowedEmail(profile.email)
+    },
+  },
+})

--- a/config/capability-inventory.json
+++ b/config/capability-inventory.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "asOf": "2026-09-08T21:53:45-04:00",
+  "asOf": "2026-09-09T11:07:29-04:00",
   "scope": "Complete at the sanitized capability-group level. Private agent names, job names, personal schedules, and machine paths remain in their owning private inventories.",
   "inventories": [
     {
@@ -214,9 +214,9 @@
       "id": "hermes-jobs",
       "title": "Hermes scheduled jobs",
       "runtime": "Hermes",
-      "count": 81,
+      "count": 82,
       "detailLevel": "grouped-private",
-      "state": "60 enabled; 21 paused",
+      "state": "61 enabled; 21 paused",
       "source": "Private Hermes cron registry",
       "countingRule": "Every job object in the active jobs registry; enabled and paused are partitioned by the enabled Boolean.",
       "items": [

--- a/config/estate-coverage.json
+++ b/config/estate-coverage.json
@@ -2157,7 +2157,7 @@
       "Hermes state",
       "Profiles, schedules, skills, and delivery state",
       "live-local",
-      "81 jobs; 60 enabled; 21 paused"
+      "82 jobs; 61 enabled; 21 paused"
     ],
     [
       "Google Drive",

--- a/config/system-registry.json
+++ b/config/system-registry.json
@@ -220,12 +220,12 @@
       "source": "This GitHub repository; runtime truth remains with each owning system",
       "measurement": "Pinned package lock, generated registry checks, production build, access matrix, search index, responsive browser review, and deployment evidence.",
       "trigger": "Reviewed documentation change merged to the deploy branch",
-      "permissions": "Public source content must remain sanitized; rendered routes require a Google-verified session whose email exactly matches the server-side allowlist",
+      "permissions": "Public source content must remain sanitized; rendered routes require a Google-verified session whose email exactly matches one of the server-side allowlist entries; domain-wide access is rejected",
       "inputs": "Reviewed registry snapshot, authoritative runbooks, official product docs, and bar-raiser findings",
       "outputs": "Searchable Nextra site, source map, operating guides, and dated system snapshot",
       "proof": "CI checks, dependency audit, production deployment, anonymous redirect and OAuth-provider checks, allowlist rejection, authenticated route checks, and issue closeout",
       "lastVerified": "2026-09-09",
-      "recovery": "Clone the repository, use the pinned Node version, regenerate the registry page, run checks and build, restore the Google OAuth client and exact-email allowlist from managed secrets, then redeploy",
+      "recovery": "Clone the repository, use the pinned Node version, regenerate the registry page, run checks and build, restore the Google OAuth client and exact-address allowlist from managed secrets, then redeploy",
       "version": "Next.js 16.3.4 · Nextra 4.6.1",
       "counts": {}
     }

--- a/config/system-registry.json
+++ b/config/system-registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "asOf": "2026-09-08T21:53:45-04:00",
+  "asOf": "2026-09-09T11:07:29-04:00",
   "scope": "Sanitized architecture and operating metadata only; no credentials, personal context, private URLs, or customer data.",
   "systems": [
     {
@@ -45,7 +45,7 @@
       "proof": "Repository checks plus the same GitHub/deploy closeout contract used by other coding runtimes",
       "lastVerified": "2026-09-08",
       "recovery": "Restore the private vault and runtime settings, run the guarded setup workflow, then compare runtime and vault inventories before use",
-      "version": "2.1.265",
+      "version": "2.1.266",
       "counts": {
         "agentDefinitions": 111,
         "slashCommands": 148,
@@ -75,8 +75,8 @@
       "version": "0.17.0 · local fork with 39 carried commits",
       "counts": {
         "profiles": 6,
-        "scheduledJobs": 81,
-        "enabledJobs": 60,
+        "scheduledJobs": 82,
+        "enabledJobs": 61,
         "pausedJobs": 21,
         "activeUserSkillManifests": 105
       }
@@ -220,12 +220,12 @@
       "source": "This GitHub repository; runtime truth remains with each owning system",
       "measurement": "Pinned package lock, generated registry checks, production build, access matrix, search index, responsive browser review, and deployment evidence.",
       "trigger": "Reviewed documentation change merged to the deploy branch",
-      "permissions": "Public source content must remain sanitized; rendered site also requires configured access credentials",
+      "permissions": "Public source content must remain sanitized; rendered routes require a Google-verified session whose email exactly matches the server-side allowlist",
       "inputs": "Reviewed registry snapshot, authoritative runbooks, official product docs, and bar-raiser findings",
       "outputs": "Searchable Nextra site, source map, operating guides, and dated system snapshot",
-      "proof": "CI checks, dependency audit, production deployment, unauthenticated/authenticated route checks, and issue closeout",
-      "lastVerified": "2026-09-08",
-      "recovery": "Clone the repository, use the pinned Node version, regenerate the registry page, run checks and build, then redeploy with access variables",
+      "proof": "CI checks, dependency audit, production deployment, anonymous redirect and OAuth-provider checks, allowlist rejection, authenticated route checks, and issue closeout",
+      "lastVerified": "2026-09-09",
+      "recovery": "Clone the repository, use the pinned Node version, regenerate the registry page, run checks and build, restore the Google OAuth client and exact-email allowlist from managed secrets, then redeploy",
       "version": "Next.js 16.3.4 · Nextra 4.6.1",
       "counts": {}
     }

--- a/lib/access-policy.mjs
+++ b/lib/access-policy.mjs
@@ -1,8 +1,17 @@
 /**
- * The allowlist is intentionally a single server-side email, not a domain.
+ * The allowlist contains exact server-side email addresses, never domains.
  * Google email addresses are case-insensitive, so comparison is normalized.
  */
-export function isAllowedEmail(email, configuredEmail = process.env.AUTHORIZED_GOOGLE_EMAIL) {
-  const allowedEmail = configuredEmail?.trim().toLowerCase()
-  return Boolean(allowedEmail && email?.trim().toLowerCase() === allowedEmail)
+export function isAllowedEmail(email, configuredEmails = process.env.AUTHORIZED_GOOGLE_EMAILS) {
+  const normalizedEmail = email?.trim().toLowerCase()
+  if (!normalizedEmail) return false
+
+  const allowlist = new Set(
+    (configuredEmails ?? '')
+      .split(',')
+      .map((candidate) => candidate.trim().toLowerCase())
+      .filter(Boolean),
+  )
+
+  return allowlist.has(normalizedEmail)
 }

--- a/lib/access-policy.mjs
+++ b/lib/access-policy.mjs
@@ -1,0 +1,8 @@
+/**
+ * The allowlist is intentionally a single server-side email, not a domain.
+ * Google email addresses are case-insensitive, so comparison is normalized.
+ */
+export function isAllowedEmail(email, configuredEmail = process.env.AUTHORIZED_GOOGLE_EMAIL) {
+  const allowedEmail = configuredEmail?.trim().toLowerCase()
+  return Boolean(allowedEmail && email?.trim().toLowerCase() === allowedEmail)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "next": "16.3.4",
+        "next-auth": "^5.0.0-beta.32",
         "nextra": "^4.6.1",
         "nextra-theme-docs": "^4.6.1",
         "react": "19.2.8",
@@ -35,6 +36,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.3.tgz",
+      "integrity": "sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7 || ^8.0.5"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@braintree/sanitize-url": {
@@ -1237,6 +1267,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/@react-aria/focus": {
       "version": "3.21.4",
@@ -3583,6 +3622,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/jose": {
+      "version": "6.2.12",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+      "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/katex": {
       "version": "0.16.47",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
@@ -4944,6 +4992,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.32.tgz",
+      "integrity": "sha512-CGlChIEWZ6LltNVxrE5yiySMID+Idpmry47JYA5lLwgD8Sx02a8M65VL0TWVz9nbnOioS/tCW/rP/0+mE7Qp4Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.3"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7 || ^8.0.5",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -5080,6 +5155,15 @@
       },
       "funding": {
         "url": "https://github.com/nebrelbug/npm-to-yarn?sponsor=1"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.8",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.8.tgz",
+      "integrity": "sha512-8N28E+a/oxfXWBgOMt+ZP/JUf/XR+IFbvkAEPP3gznXOMv9BpAAwiIj0TFNz3tGTPc0ZQ8zmWBNgN1nAys0gng==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/onetime": {
@@ -5298,6 +5382,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/property-information": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "next": "16.3.4",
+    "next-auth": "^5.0.0-beta.32",
     "nextra": "^4.6.1",
     "nextra-theme-docs": "^4.6.1",
     "react": "19.2.8",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,55 +1,28 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@/auth'
+import { isAllowedEmail } from '@/lib/access-policy.mjs'
+import { NextResponse } from 'next/server'
 
 // This is a secondary gate for the rendered site, not a confidentiality boundary
 // for the public GitHub source. Published content must remain sanitized.
 
 export const config = {
-  // Pagefind runs in a web worker that cannot reliably reuse HTTP Basic
-  // credentials. Its index mirrors this already-public, sanitized repository.
-  matcher: ['/((?!_next/static|_next/image|_pagefind|favicon.ico|robots.txt|sitemap.xml).*)'],
+  // Auth.js owns /api/auth. Pagefind and machine-readable navigation remain
+  // public because they mirror this already-public, sanitized repository.
+  matcher: ['/((?!api/auth|_next/static|_next/image|_pagefind|favicon.ico|robots.txt|sitemap.xml).*)'],
 }
 
-function unauthorized() {
-  return new NextResponse('Authentication required.', {
-    status: 401,
-    headers: {
-      'Cache-Control': 'private, no-store, max-age=0',
-      Vary: 'Authorization',
-      'WWW-Authenticate': 'Basic realm="Super Agents Docs", charset="UTF-8"',
-    },
-  })
+function protectedResponse(response: NextResponse) {
+  response.headers.set('Cache-Control', 'private, no-store, max-age=0')
+  response.headers.set('Vary', 'Cookie')
+  return response
 }
 
-export function proxy(req: NextRequest) {
-  // Preserve the established production contract: deployments may configure
-  // only DOCS_PASSWORD, in which case the username remains "gui".
-  const expectedUser = process.env.DOCS_USER || 'gui'
-  const expectedPass = process.env.DOCS_PASSWORD
-
-  if (!expectedPass) {
-    return new NextResponse('Site auth not configured.', {
-      status: 503,
-      headers: { 'Cache-Control': 'private, no-store, max-age=0' },
-    })
+export const proxy = auth((req) => {
+  if (isAllowedEmail(req.auth?.user?.email)) {
+    return protectedResponse(NextResponse.next())
   }
 
-  const header = req.headers.get('authorization')
-  if (header?.startsWith('Basic ')) {
-    try {
-      const decoded = atob(header.slice(6))
-      const sep = decoded.indexOf(':')
-      if (sep < 1) return unauthorized()
-      const user = decoded.slice(0, sep)
-      const pass = decoded.slice(sep + 1)
-      if (user === expectedUser && pass === expectedPass) {
-        const response = NextResponse.next()
-        response.headers.set('Cache-Control', 'private, no-store, max-age=0')
-        response.headers.set('Vary', 'Authorization')
-        return response
-      }
-    } catch {
-      // fall through to 401
-    }
-  }
-  return unauthorized()
-}
+  const signInUrl = new URL('/api/auth/signin', req.nextUrl.origin)
+  signInUrl.searchParams.set('callbackUrl', `${req.nextUrl.pathname}${req.nextUrl.search}`)
+  return protectedResponse(NextResponse.redirect(signInUrl))
+})

--- a/scripts/smoke-site.mjs
+++ b/scripts/smoke-site.mjs
@@ -2,12 +2,12 @@ import { spawn } from 'node:child_process'
 import { readdirSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { legacyRedirects } from '../config/legacy-redirects.mjs'
+import { isAllowedEmail } from '../lib/access-policy.mjs'
 
 const port = 3219
 const baseUrl = `http://127.0.0.1:${port}`
 const canonicalSiteUrl = 'https://superagents-docs.vercel.app'
-const validAuth = `Basic ${Buffer.from('gui:local-smoke-password').toString('base64')}`
-const wrongAuth = `Basic ${Buffer.from('wrong:wrong').toString('base64')}`
+const allowedEmail = 'owner@example.com'
 const countDocumentationPages = (directory) => readdirSync(directory, { withFileTypes: true })
   .reduce((total, entry) => {
     const path = join(directory, entry.name)
@@ -16,7 +16,15 @@ const countDocumentationPages = (directory) => readdirSync(directory, { withFile
   }, 0)
 const expectedPageCount = countDocumentationPages(resolve('app'))
 const server = spawn(process.execPath, ['node_modules/next/dist/bin/next', 'start'], {
-  env: { ...process.env, PORT: String(port), DOCS_USER: '', DOCS_PASSWORD: 'local-smoke-password' },
+  env: {
+    ...process.env,
+    PORT: String(port),
+    AUTH_GOOGLE_ID: 'local-google-client-id',
+    AUTH_GOOGLE_SECRET: 'local-google-client-secret',
+    AUTH_SECRET: 'local-smoke-secret-that-is-long-enough-for-testing',
+    AUTH_TRUST_HOST: 'true',
+    AUTHORIZED_GOOGLE_EMAIL: allowedEmail,
+  },
   stdio: ['ignore', 'pipe', 'pipe'],
 })
 
@@ -50,22 +58,29 @@ async function response(path, options = {}) {
 try {
   await waitForServer()
 
-  assert((await response('/')).status === 401, 'Anonymous home request must return 401')
-  assert((await response('/', { headers: { Authorization: wrongAuth } })).status === 401, 'Wrong credentials must return 401')
+  assert(isAllowedEmail('OWNER@example.com', allowedEmail), 'Allowlist must accept only the normalized configured email')
+  assert(!isAllowedEmail('other@example.com', allowedEmail), 'Allowlist must reject a different email')
+  assert(!isAllowedEmail(allowedEmail, ''), 'Allowlist must fail closed when it is not configured')
 
-  const home = await response('/', { headers: { Authorization: validAuth } })
-  assert(home.status === 200, 'Authenticated home request must return 200')
-  assert((await home.text()).includes('Super Agents'), 'Authenticated home must contain the portal title')
+  const anonymousHome = await response('/')
+  assert(anonymousHome.status === 307, 'Anonymous home request must redirect to Google sign-in')
+  const signInLocation = new URL(anonymousHome.headers.get('location'), baseUrl)
+  assert(signInLocation.pathname === '/api/auth/signin', 'Anonymous home must redirect to the Auth.js sign-in route')
+  assert(signInLocation.searchParams.get('callbackUrl') === '/', 'Sign-in redirect must preserve the requested route')
+
+  const providers = await response('/api/auth/providers')
+  const providerCatalog = await providers.json()
+  assert(providers.status === 200 && providerCatalog.google?.name === 'Google', 'Auth.js must expose only the Google provider')
+
+  const signInPage = await response('/api/auth/signin')
+  assert(signInPage.status === 200 && (await signInPage.text()).includes('Google'), 'Google sign-in page must render')
 
   const rsc = await response('/reference/system-registry', { headers: { RSC: '1' } })
-  assert(rsc.status === 401, 'Anonymous RSC request must return 401')
-
-  const inventory = await response('/reference/capability-inventory', { headers: { Authorization: validAuth } })
-  assert(inventory.status === 200 && (await inventory.text()).includes('Codex personal skills'), 'Capability inventory must render')
+  assert(rsc.status === 307, 'Anonymous RSC request must redirect to sign-in')
 
   for (const redirect of legacyRedirects) {
     const oldPath = redirect.source.replace('/:path*', '')
-    const redirected = await response(oldPath, { headers: { Authorization: validAuth } })
+    const redirected = await response(oldPath)
     assert(redirected.status === 308, `${oldPath} must return a permanent redirect`)
     assert(redirected.headers.get('location') === redirect.destination, `${oldPath} must redirect to ${redirect.destination}`)
   }
@@ -83,7 +98,7 @@ try {
 
   assert(sitemap.status === 200 && sitemapLocations.length === expectedPageCount, `Public sitemap must list all ${expectedPageCount} docs pages`)
   assert(sitemapLocations.every((location) => location === canonicalSiteUrl || location.startsWith(`${canonicalSiteUrl}/`)), `Every sitemap URL must use ${canonicalSiteUrl}`)
-  console.log(`Site smoke checks passed: auth, RSC, ${legacyRedirects.length} redirects, inventory, search, robots, and sitemap.`)
+  console.log(`Site smoke checks passed: Google provider, exact-email allowlist, auth redirects, RSC, ${legacyRedirects.length} redirects, search, robots, and sitemap.`)
 } finally {
   if (server.exitCode === null) {
     server.kill('SIGTERM')

--- a/scripts/smoke-site.mjs
+++ b/scripts/smoke-site.mjs
@@ -7,7 +7,7 @@ import { isAllowedEmail } from '../lib/access-policy.mjs'
 const port = 3219
 const baseUrl = `http://127.0.0.1:${port}`
 const canonicalSiteUrl = 'https://superagents-docs.vercel.app'
-const allowedEmail = 'owner@example.com'
+const allowedEmails = 'owner@example.com,personal@example.com'
 const countDocumentationPages = (directory) => readdirSync(directory, { withFileTypes: true })
   .reduce((total, entry) => {
     const path = join(directory, entry.name)
@@ -23,7 +23,7 @@ const server = spawn(process.execPath, ['node_modules/next/dist/bin/next', 'star
     AUTH_GOOGLE_SECRET: 'local-google-client-secret',
     AUTH_SECRET: 'local-smoke-secret-that-is-long-enough-for-testing',
     AUTH_TRUST_HOST: 'true',
-    AUTHORIZED_GOOGLE_EMAIL: allowedEmail,
+    AUTHORIZED_GOOGLE_EMAILS: allowedEmails,
   },
   stdio: ['ignore', 'pipe', 'pipe'],
 })
@@ -58,9 +58,10 @@ async function response(path, options = {}) {
 try {
   await waitForServer()
 
-  assert(isAllowedEmail('OWNER@example.com', allowedEmail), 'Allowlist must accept only the normalized configured email')
-  assert(!isAllowedEmail('other@example.com', allowedEmail), 'Allowlist must reject a different email')
-  assert(!isAllowedEmail(allowedEmail, ''), 'Allowlist must fail closed when it is not configured')
+  assert(isAllowedEmail('OWNER@example.com', allowedEmails), 'Allowlist must accept the normalized first configured email')
+  assert(isAllowedEmail('personal@example.com', allowedEmails), 'Allowlist must accept the second configured email')
+  assert(!isAllowedEmail('other@example.com', allowedEmails), 'Allowlist must reject an unlisted email from the same domain')
+  assert(!isAllowedEmail('owner@example.com', ''), 'Allowlist must fail closed when it is not configured')
 
   const anonymousHome = await response('/')
   assert(anonymousHome.status === 307, 'Anonymous home request must redirect to Google sign-in')


### PR DESCRIPTION
Closes #10 after production verification.\n\nImplements Auth.js Google OAuth, exact normalized multi-address allowlisting at sign-in and on every protected request, explicit rejection of domain-wide access, fail-closed configuration, requested-route preservation, public OAuth/Pagefind/robots/sitemap surfaces, updated governance and recovery contracts, and refreshed live registry facts. The private allowlist values are not committed.\n\nVerified locally: 33/33 runtime measurements, documentation checks, dependency audit, production build, Google-provider and two-address allowlist smoke tests, same-domain rejection, 26 legacy redirects, RSC redirect behavior, Pagefind 48, and canonical sitemap 48.\n\nPending before merge: finish Google account verification; create a Google OAuth web client with callback https://superagents-docs.vercel.app/api/auth/callback/google; configure managed Vercel environment variables; preview both approved accounts and a rejected account; then merge, deploy, and retire DOCS_PASSWORD only after production passes.