### PR TITLE
Enforce canonical Super Agents naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,15 @@
 - Do not publish personal context, private URLs, absolute home paths, customer data, or destructive recovery shortcuts.
 - Before shipping, run `npm run check` and `npm run build`, review the rendered site, then complete the GitHub/deploy/live-proof loop.
 
+## Canonical Naming
+
+- The product and system umbrella is **Super Agents**. Use that exact two-word, title-case form in prose and interface copy.
+- The canonical machine slug is `superagents`. The GitHub repository and Vercel project must both use this slug.
+- The canonical production hostname is `superagents-docs.vercel.app`.
+- Never introduce `InnerOS`, `inneros`, or `inner-os` into an active project name, domain, deployment alias, branch, environment variable, package, route, or new documentation title.
+- The former name may appear only in an explicitly historical record or while removing a legacy identifier. Do not preserve compatibility aliases unless Gui explicitly requests one.
+- Before shipping naming-related work, search the complete current tree and verify the GitHub repository, Vercel project, production aliases, and live page metadata against this contract.
+
 <!-- BEGIN:nextjs-agent-rules -->
 
 # This is NOT the Next.js you know

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ The portal documents runtimes, capabilities, repositories, devices, data sources
 
 - Website: [superagents-docs.vercel.app](https://superagents-docs.vercel.app)
 - Source and issues: [GuillaumeRacine/superagents](https://github.com/GuillaumeRacine/superagents)
-- Previous GitHub links redirect to this repository. The old Vercel hostname remains a compatibility redirect.
+- Product name: **Super Agents**
+- GitHub repository slug and Vercel project name: `superagents`
+
+The retired Vercel hostname is intentionally detached rather than maintained as a compatibility alias. See [Canonical Naming](https://superagents-docs.vercel.app/governance/naming) for the naming contract.
 
 ## Local development
 

--- a/REPO_MANIFEST.md
+++ b/REPO_MANIFEST.md
@@ -7,6 +7,7 @@ Canonical Super Agents website and sanitized derived index for Gui's complete ag
 ## Authority
 
 - This repository owns the portal's navigation, explanatory content, publication policy, and public registry snapshot.
+- `AGENTS.md` and `/governance/naming` own the canonical Super Agents naming contract for this repository and its deployment.
 - `config/system-registry.json` owns volatile facts published by the site.
 - Each runtime, private system repository, and deployed surface remains authoritative for its live behavior.
 

--- a/app/governance/_meta.js
+++ b/app/governance/_meta.js
@@ -1,5 +1,6 @@
 export default {
   index: 'Overview',
+  naming: 'Canonical Naming',
   permissions: 'Permissions',
   secrets: 'Secrets',
   documentation: 'Documentation Governance'

--- a/app/governance/naming/page.mdx
+++ b/app/governance/naming/page.mdx
@@ -1,0 +1,21 @@
+# Canonical Naming
+
+One name identifies the documentation umbrella across human-facing and machine-facing surfaces.
+
+## Naming contract
+
+| Surface | Canonical value |
+| --- | --- |
+| Product and system umbrella | **Super Agents** |
+| GitHub repository | `GuillaumeRacine/superagents` |
+| Vercel project | `superagents` |
+| Production website | `superagents-docs.vercel.app` |
+| Environment-variable prefix | `SUPERAGENTS_` |
+
+Use **Super Agents** in prose and interface copy. Use `superagents` where a platform requires a lowercase slug. Hyphenate only when an external platform requires it; do not create a second brand spelling.
+
+## Rename rule
+
+New repositories, deployments, domains, aliases, packages, branches, routes, variables, and documentation titles must follow the canonical values above. Former names belong only in clearly labeled history and must not survive as compatibility aliases unless Gui explicitly asks for one.
+
+Every naming change must verify the current repository, deployment project, production aliases, live metadata, and repository-wide text search before closeout.

--- a/scripts/audit-estate.mjs
+++ b/scripts/audit-estate.mjs
@@ -433,8 +433,7 @@ if (!existsSync(storagePolicyPath)) throw new Error('Canonical storage policy is
 const storagePolicy = readFileSync(storagePolicyPath, 'utf8')
 const storagePolicyRevision = createHash('sha256').update(storagePolicy).digest('hex').slice(0, 16)
 const detectedHost = command('hostname', ['-s']).toLowerCase()
-// SUPERAGENTS_DEVICE_ID is canonical; retain the former name for one migration window.
-const detectedDeviceId = process.env.SUPERAGENTS_DEVICE_ID || process.env.INNEROS_DEVICE_ID
+const detectedDeviceId = process.env.SUPERAGENTS_DEVICE_ID
   || (/office[- ]?mini/.test(detectedHost) ? 'main-mac-mini' : /studio/.test(detectedHost) ? 'studio-mac-mini' : /macbook/.test(detectedHost) ? 'macbook' : null)
 const policyDeviceRows = [...storagePolicy.matchAll(/^\| \*\*(Mac mini \(main, here\)|Mac mini \(studio\)|MacBook \(laptop, on-the-go\))\*\* \| ([^|]+) \| ([^|]+) \|$/gm)]
 const devices = policyDeviceRows.map(([, policyTitle, role, localState]) => {

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -18,6 +18,7 @@ function walk(directory) {
 
 const files = walk(root).filter((file) => textExtensions.has(extname(file)))
 const publishable = files.filter((file) => !['package-lock.json', 'scripts/check-docs.mjs'].includes(relative(root, file)))
+const historicalBrandAllowlist = new Set(['AGENTS.md', 'app/reference/history/page.mdx'])
 
 const forbiddenPublicationPatterns = [
   [/\/Users\/[A-Za-z0-9._-]+\//g, 'absolute home path'],
@@ -31,9 +32,13 @@ const forbiddenPublicationPatterns = [
 
 for (const file of publishable) {
   const content = readFileSync(file, 'utf8')
+  const repositoryPath = relative(root, file)
   for (const [pattern, description] of forbiddenPublicationPatterns) {
     pattern.lastIndex = 0
-    if (pattern.test(content)) failures.push(`${relative(root, file)} contains ${description}`)
+    if (pattern.test(content)) failures.push(`${repositoryPath} contains ${description}`)
+  }
+  if (!historicalBrandAllowlist.has(repositoryPath) && /\binner[ _-]?os\b/i.test(content)) {
+    failures.push(`${repositoryPath} contains the retired product name outside the historical allowlist`)
   }
 }
 


### PR DESCRIPTION
## Summary
- establish `Super Agents` / `superagents` as the only active naming contract
- document the canonical GitHub repo, Vercel project, hostname, and environment-variable prefix
- remove the retired device-variable compatibility fallback
- fail docs checks if the former brand reappears outside the explicit history/agent-policy allowlist
- record that the retired Vercel hostname is detached

## External change already applied
- removed the legacy production alias from the Vercel project
- verified `https://inneros-docs.vercel.app` returns 404
- verified `https://superagents-docs.vercel.app` remains live behind its 401 access gate
- verified Vercel project ID `prj_1Ar5OjwtRyT55le5QkGKeVGQ1urs` is named `superagents`

## Verification
- `npm run check`
- `npm run build`
- `npm run smoke`
- current-tree retired-name scan: only `AGENTS.md` policy and `/reference/history` contain it

## Residual risk
- immutable historical deployment URLs may retain their original generated names; they are not active project names or production aliases.