### PR TITLE
Publish complete agent and offline documentation exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ The portal documents runtimes, capabilities, repositories, devices, data sources
 - Product name: **Super Agents**
 - GitHub repository slug and Vercel project name: `superagents`
 
+## Agent and offline exports
+
+- Complete Markdown corpus: [superagents-docs.vercel.app/superagents.md](https://superagents-docs.vercel.app/superagents.md)
+- Agent discovery index: [superagents-docs.vercel.app/llms.txt](https://superagents-docs.vercel.app/llms.txt)
+- XML sitemap: [superagents-docs.vercel.app/sitemap.xml](https://superagents-docs.vercel.app/sitemap.xml)
+
+The Markdown corpus and discovery index are generated from every canonical page and verified for drift in CI.
+
 The retired Vercel hostname is intentionally detached rather than maintained as a compatibility alias. See [Canonical Naming](https://superagents-docs.vercel.app/governance/naming) for the naming contract.
 
 ## Local development

--- a/app/reference/_meta.js
+++ b/app/reference/_meta.js
@@ -3,6 +3,7 @@ export default {
   'system-registry': 'System Registry',
   'capability-inventory': 'Capability Inventory',
   'canonical-sources': 'Canonical Sources',
+  'agent-export': 'Agent & Offline Export',
   glossary: 'Glossary',
   history: 'History & Scope'
 }

--- a/app/reference/agent-export/page.mdx
+++ b/app/reference/agent-export/page.mdx
@@ -1,0 +1,20 @@
+# Agent & Offline Export
+
+Use these generated, public artifacts to give an agent the complete sanitized documentation set or to save a portable copy on any device.
+
+## Download and discovery
+
+- [Download the complete Markdown corpus](/superagents.md) — every canonical documentation page in one file, with its source path and website route
+- [Open `llms.txt`](/llms.txt) — an agent-friendly discovery index linking the complete export, sitemap, repository, and every documentation page
+- [Open the XML sitemap](/sitemap.xml) — the canonical machine-readable route list
+- [Open the GitHub repository](https://github.com/GuillaumeRacine/superagents) — versioned sources and export generator
+
+The Markdown corpus and `llms.txt` are intentionally public because they contain only the same sanitized content already published in the public repository. Interactive website pages still require an approved Google account.
+
+## Agent usage
+
+Give an agent `https://superagents-docs.vercel.app/llms.txt` for discovery or `https://superagents-docs.vercel.app/superagents.md` when it needs the entire corpus in one request. On a phone or computer, open the Markdown link and use the browser's download or **Save to Files** action.
+
+## Freshness contract
+
+`npm run docs:generate` rebuilds both exports from every `app/**/page.mdx` file. CI compares the committed artifacts with the canonical pages and fails if a page is missing or either export is stale.

--- a/app/reference/page.mdx
+++ b/app/reference/page.mdx
@@ -3,6 +3,7 @@
 - [System Registry](/reference/system-registry) — generated, dated operating contracts and snapshot facts
 - [Capability Inventory](/reference/capability-inventory) — generated, sanitized catalogs with explicit counting rules
 - [Canonical Sources](/reference/canonical-sources) — where to verify each subject
+- [Agent & Offline Export](/reference/agent-export) — download every page as one Markdown file or discover routes through `llms.txt` and the XML sitemap
 - [Glossary](/reference/glossary) — shared language for state, authority, and proof
 - [History & Scope](/reference/history) — why this portal replaced earlier documentation structures
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -27,6 +27,21 @@ export default withNextra({
           { key: 'X-Robots-Tag', value: 'noindex, nofollow, noarchive' },
         ],
       },
+      {
+        source: '/superagents.md',
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=300, must-revalidate' },
+          { key: 'Content-Disposition', value: 'attachment; filename="superagents.md"' },
+          { key: 'Content-Type', value: 'text/markdown; charset=utf-8' },
+        ],
+      },
+      {
+        source: '/llms.txt',
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=300, must-revalidate' },
+          { key: 'Content-Type', value: 'text/plain; charset=utf-8' },
+        ],
+      },
     ]
   },
 })

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind",
     "start": "next start",
     "smoke": "node scripts/smoke-site.mjs",
-    "docs:generate": "node scripts/generate-system-registry.mjs && node scripts/generate-estate-pages.mjs",
+    "docs:generate": "node scripts/generate-system-registry.mjs && node scripts/generate-estate-pages.mjs && node scripts/generate-agent-exports.mjs",
     "docs:audit-estate": "node scripts/audit-estate.mjs && node scripts/generate-estate-pages.mjs",
     "docs:verify-live": "node scripts/verify-live-registry.mjs",
-    "docs:check": "node scripts/generate-system-registry.mjs --check && node scripts/generate-estate-pages.mjs --check && node scripts/check-docs.mjs",
+    "docs:check": "node scripts/generate-system-registry.mjs --check && node scripts/generate-estate-pages.mjs --check && node scripts/generate-agent-exports.mjs --check && node scripts/check-docs.mjs",
     "check": "npm run docs:check && npm audit --omit=dev --audit-level=high"
   },
   "keywords": [

--- a/proxy.ts
+++ b/proxy.ts
@@ -8,7 +8,7 @@ import { NextResponse } from 'next/server'
 export const config = {
   // Auth.js owns /api/auth. Pagefind and machine-readable navigation remain
   // public because they mirror this already-public, sanitized repository.
-  matcher: ['/((?!api/auth|_next/static|_next/image|_pagefind|favicon.ico|robots.txt|sitemap.xml).*)'],
+  matcher: ['/((?!api/auth|_next/static|_next/image|_pagefind|favicon.ico|robots.txt|sitemap.xml|superagents.md|llms.txt).*)'],
 }
 
 function protectedResponse(response: NextResponse) {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,62 @@
+# Super Agents
+
+> A sanitized, evidence-backed map of Gui's complete agentic operating environment.
+
+## Complete export
+
+- [Complete Markdown documentation](https://superagents-docs.vercel.app/superagents.md): One generated file containing all 50 canonical pages.
+- [XML sitemap](https://superagents-docs.vercel.app/sitemap.xml): Machine-readable list of canonical website routes.
+- [GitHub source](https://github.com/GuillaumeRacine/superagents): Versioned source and generation scripts.
+
+## Documentation pages
+
+- [Super Agents](https://superagents-docs.vercel.app)
+- [Architecture](https://superagents-docs.vercel.app/architecture)
+- [Design Principles](https://superagents-docs.vercel.app/architecture/design-principles)
+- [Sources of Truth](https://superagents-docs.vercel.app/architecture/sources-of-truth)
+- [Automation & Operations](https://superagents-docs.vercel.app/automation)
+- [Fleet Evidence](https://superagents-docs.vercel.app/automation/fleet-evidence)
+- [NightCrew](https://superagents-docs.vercel.app/automation/nightcrew)
+- [Scheduling](https://superagents-docs.vercel.app/automation/scheduling)
+- [Capabilities](https://superagents-docs.vercel.app/capabilities)
+- [Agents & Subagents](https://superagents-docs.vercel.app/capabilities/agents-subagents)
+- [Browser & Computer Use](https://superagents-docs.vercel.app/capabilities/browser-computer-use)
+- [MCP & Tools](https://superagents-docs.vercel.app/capabilities/mcp-tools)
+- [Skills & Plugins](https://superagents-docs.vercel.app/capabilities/skills-plugins)
+- [Context & Memory](https://superagents-docs.vercel.app/context-memory)
+- [Context Layering](https://superagents-docs.vercel.app/context-memory/layering)
+- [Storage Model](https://superagents-docs.vercel.app/context-memory/storage)
+- [Estate Coverage](https://superagents-docs.vercel.app/estate)
+- [Agentic Components](https://superagents-docs.vercel.app/estate/components)
+- [Data Sources & Integrations](https://superagents-docs.vercel.app/estate/data-sources)
+- [Devices & Hosts](https://superagents-docs.vercel.app/estate/devices)
+- [Repository Coverage](https://superagents-docs.vercel.app/estate/repositories)
+- [Governance & Safety](https://superagents-docs.vercel.app/governance)
+- [Documentation Governance](https://superagents-docs.vercel.app/governance/documentation)
+- [Canonical Naming](https://superagents-docs.vercel.app/governance/naming)
+- [Permissions](https://superagents-docs.vercel.app/governance/permissions)
+- [Secrets](https://superagents-docs.vercel.app/governance/secrets)
+- [Recovery & Rebuild](https://superagents-docs.vercel.app/recovery)
+- [Disaster Rebuild Readiness](https://superagents-docs.vercel.app/recovery/disaster-rebuild)
+- [Maintenance](https://superagents-docs.vercel.app/recovery/maintenance)
+- [New Device](https://superagents-docs.vercel.app/recovery/new-device)
+- [Reference](https://superagents-docs.vercel.app/reference)
+- [Agent & Offline Export](https://superagents-docs.vercel.app/reference/agent-export)
+- [Canonical Sources](https://superagents-docs.vercel.app/reference/canonical-sources)
+- [Capability Inventory](https://superagents-docs.vercel.app/reference/capability-inventory)
+- [Glossary](https://superagents-docs.vercel.app/reference/glossary)
+- [History & Scope](https://superagents-docs.vercel.app/reference/history)
+- [System Registry](https://superagents-docs.vercel.app/reference/system-registry)
+- [Systems & Surfaces](https://superagents-docs.vercel.app/runtimes)
+- [Claude Code](https://superagents-docs.vercel.app/runtimes/claude-code)
+- [Codex](https://superagents-docs.vercel.app/runtimes/codex)
+- [Companions & Compatibility](https://superagents-docs.vercel.app/runtimes/companions)
+- [Hermes](https://superagents-docs.vercel.app/runtimes/hermes)
+- [Start Here](https://superagents-docs.vercel.app/start-here)
+- [Choose a Runtime](https://superagents-docs.vercel.app/start-here/choose-a-runtime)
+- [Operating Loop](https://superagents-docs.vercel.app/start-here/operating-loop)
+- [Workflows](https://superagents-docs.vercel.app/workflows)
+- [Personal Operations](https://superagents-docs.vercel.app/workflows/personal-operations)
+- [Project Delivery](https://superagents-docs.vercel.app/workflows/project-delivery)
+- [Publishing](https://superagents-docs.vercel.app/workflows/publishing)
+- [Research](https://superagents-docs.vercel.app/workflows/research)

--- a/public/superagents.md
+++ b/public/superagents.md
@@ -1,0 +1,2232 @@
+# Super Agents — Complete Documentation Export
+
+> Generated from every canonical documentation page in the Super Agents repository.
+
+- Canonical site: https://superagents-docs.vercel.app
+- Source: https://github.com/GuillaumeRacine/superagents
+- Registry snapshot: 2026-09-09T11:07:29-04:00
+- Pages included: 50
+
+This file is generated. Edit the owning page in `app/`, then run `npm run docs:generate`.
+
+---
+
+<!-- source-page: app/page.mdx | route: https://superagents-docs.vercel.app -->
+
+Source page: [Super Agents](https://superagents-docs.vercel.app)
+
+# Super Agents
+
+> The sanitized, evidence-backed map of Gui's agent runtimes, tools, skills, context, automations, workflows, repositories, devices, and operating rules. Registry snapshot verified **September 8, 2026**.
+
+Super Agents is the umbrella for the full agentic system—not one app or one runtime. It coordinates interactive agents, persistent schedulers, skills, tools, context, shared services, repositories, devices, and GitHub-backed proof. This site is the navigation layer; each owning repository or runtime remains authoritative for live state.
+
+## Find the answer you need
+
+| Question | Go to |
+|---|---|
+| Which agent should handle this task? | [Choose a runtime](/start-here/choose-a-runtime) |
+| How does work move from intent to production? | [Operating loop](/start-here/operating-loop) |
+| Where does each kind of information belong? | [Sources of truth](/architecture/sources-of-truth) |
+| What is installed and what is actually active? | [System registry](/reference/system-registry) |
+| Which skills, plugins, agents, commands, profiles, jobs, and MCPs exist? | [Capability inventory](/reference/capability-inventory) |
+| Which repositories, devices, and data sources were actually scanned? | [Estate coverage](/estate) |
+| What may run autonomously? | [Permissions](/governance/permissions) |
+| Could I rebuild everything after total device loss? | [Disaster rebuild readiness](/recovery/disaster-rebuild) |
+| How do I restore or change one device? | [Recovery & Rebuild](/recovery) |
+
+## System at a glance
+
+```text
+Gui / messages / schedules
+          │
+          ▼
+Codex ─ Claude Code ─ Hermes ─ Companion CLIs
+  │           │          │
+  └──── skills, tools, MCP services ────┘
+                       │
+          Context control plane + vault
+                       │
+          GitHub → deployment → live proof
+```
+
+## Active surfaces
+
+| Surface | Primary role | Authority |
+|---|---|---|
+| Codex | Project delivery and app-integrated work | Task policy, AGENTS.md, repository |
+| Claude Code | Specialist agents, commands, and plugins | CLAUDE.md, runtime settings, repository |
+| Hermes | Messaging, schedules, and unattended operations | Profiles, job definitions, approval class |
+| Context | Fleet inventory, evidence, and automation contracts | Private Context repository |
+| Knowledge vault | Curated decisions, identity, goals, and durable context | Private Git-backed vault |
+
+## Four rules that keep it coherent
+
+1. **Ownership beats copying.** Link to an authoritative source instead of cloning volatile detail.
+2. **Installed is not active, and success is not proof.** State and evidence are recorded separately.
+3. **Least authority wins.** Read-only work is easy to delegate; external writes need an explicit policy or approval.
+4. **GitHub closes the loop.** Material work ends with tests, commit, deployment when relevant, live verification, and recorded evidence.
+
+Start with [the orientation guide](/start-here).
+
+---
+
+<!-- source-page: app/architecture/page.mdx | route: https://superagents-docs.vercel.app/architecture -->
+
+Source page: [Architecture](https://superagents-docs.vercel.app/architecture)
+
+# Architecture
+
+Super Agents separates orchestration, execution, context, services, and evidence so that no single tool silently becomes authoritative for everything.
+
+| Layer | Responsibility |
+|---|---|
+| Intent | Gui, project brief, message, or schedule |
+| Orchestration | Runtime selection, task decomposition, policy, approvals |
+| Execution | Codex, Claude Code, Hermes, and companion CLIs |
+| Capability | Agents, skills, commands, plugins, MCP services, browser and computer use |
+| Context | Repository instructions, curated vault knowledge, memories, and live evidence |
+| Proof | Tests, builds, Git commits, deployments, live checks, and issue records |
+
+The [system registry](/reference/system-registry) gives every major surface an owner, trigger, permission boundary, inputs, outputs, proof, and recovery path.
+
+---
+
+<!-- source-page: app/architecture/design-principles/page.mdx | route: https://superagents-docs.vercel.app/architecture/design-principles -->
+
+Source page: [Design Principles](https://superagents-docs.vercel.app/architecture/design-principles)
+
+# Design Principles
+
+## Explicit ownership
+
+Every operating surface needs an owner, trigger, permission boundary, inputs, outputs, proof, and recovery path. If any field is unknown, the system is not ready for unattended use.
+
+## Derived views, canonical sources
+
+Dashboards and docs accelerate navigation. They never outrank the repository, scheduler, vault, or live surface they summarize.
+
+## Evidence over green lights
+
+A successful process exit proves that a process exited successfully. It does not prove delivery, correctness, freshness, or user-visible behavior. Independent evidence closes that gap.
+
+## Least authority and narrow tools
+
+Use the narrowest capable surface. Keep notification, external mutation, financial, and irreversible actions behind explicit approval classes.
+
+## Recoverable by construction
+
+Persistent system state belongs in Git, managed cloud stores, or 1Password references. Active work uses internal storage; external disks are cold backup only.
+
+---
+
+<!-- source-page: app/architecture/sources-of-truth/page.mdx | route: https://superagents-docs.vercel.app/architecture/sources-of-truth -->
+
+Source page: [Sources of Truth](https://superagents-docs.vercel.app/architecture/sources-of-truth)
+
+# Sources of Truth
+
+Authority follows the type of information, not whichever runtime saw it most recently.
+
+| Information | Canonical owner |
+|---|---|
+| Code, infrastructure, and shipped documentation | GitHub repository |
+| Live customer-facing behavior | Deployed production surface |
+| Automation definitions and fleet evidence | Context repository and owning scheduler |
+| Curated decisions, goals, identity, and durable knowledge | Private knowledge vault |
+| Files and structured working data | Google Drive where designated |
+| Apple-native personal data | iCloud |
+| Credentials | 1Password |
+| Runtime-local state, caches, and sessions | Local internal storage; recoverable or transient |
+| Cold snapshots | External backup storage when mounted |
+
+This portal links those owners together. It must not claim to replace them.
+
+## Resolve conflicts
+
+1. Prefer the source assigned to that information type.
+2. Prefer live evidence over an old narrative page.
+3. Reconcile divergent runtime and vault inventories; do not assume they are mirrored.
+4. Correct the owning source first, then refresh derived documentation and its verification date.
+
+---
+
+<!-- source-page: app/automation/page.mdx | route: https://superagents-docs.vercel.app/automation -->
+
+Source page: [Automation & Operations](https://superagents-docs.vercel.app/automation)
+
+# Automation & Operations
+
+Super Agents uses several scheduling surfaces, each with a distinct job.
+
+| Surface | Use |
+|---|---|
+| Hermes cron | Primary persistent schedules and message-driven operations |
+| Context workflows | Automation definitions, collectors, evidence contracts, and fleet reporting |
+| Codex scheduled tasks | Lightweight task follow-ups and recurring work attached to Codex |
+| GitHub Actions | Repository CI, security checks, and deployment gates |
+| Launch services | Local process availability where a host service must stay running |
+
+Do not count a scheduler entry as a verified outcome. Every material automation needs a destination and an independent evidence signal.
+
+Start with [Scheduling](/automation/scheduling), then use [Fleet Evidence](/automation/fleet-evidence) to interpret results.
+
+The [Capability Inventory](/reference/capability-inventory) records current profiles, job totals and states, and the sanitized schedule categories.
+
+---
+
+<!-- source-page: app/automation/fleet-evidence/page.mdx | route: https://superagents-docs.vercel.app/automation/fleet-evidence -->
+
+Source page: [Fleet Evidence](https://superagents-docs.vercel.app/automation/fleet-evidence)
+
+# Fleet Evidence
+
+System state and evidence are intentionally separate.
+
+| State | Meaning |
+|---|---|
+| Installed | Code or configuration exists |
+| Active | Part of a current operating path |
+| Healthy | A bounded operational check passed |
+| Verified | Independent evidence supports the claimed outcome |
+| Unverified | The system may have run, but proof is absent or stale |
+| Paused | Deliberately disabled |
+| Failed | Execution or outcome check failed |
+
+The private Context inventory and scoreboard are authoritative for current fleet state. This site publishes a dated, sanitized subset in the [system registry](/reference/system-registry).
+
+## Good evidence
+
+Examples include an expected artifact with fresh content, an API response from the destination, a deployed URL behaving correctly, a delivered-message identifier, or a repository check attached to a commit.
+
+A log line saying “success” is supporting telemetry, not independent proof.
+
+---
+
+<!-- source-page: app/automation/nightcrew/page.mdx | route: https://superagents-docs.vercel.app/automation/nightcrew -->
+
+Source page: [NightCrew](https://superagents-docs.vercel.app/automation/nightcrew)
+
+# NightCrew
+
+NightCrew is the overnight automation suite owned by Context and invoked by Hermes.
+
+At the September 8 snapshot, the default scheduled run contains **19 sections** and starts daily at **3:00 a.m. local time** through its Hermes job. Additional methods exist for explicit manual use; they must not be described as nightly merely because they are implemented.
+
+## Contract
+
+- Context owns the current section definitions and runbook.
+- Hermes owns the schedule and invocation record.
+- Each section owns its outcome evidence.
+- The fleet scoreboard distinguishes verified, unverified, failed, idle, and paused states.
+
+When changing NightCrew, update the owning Context documentation first, test the relevant section directly, then refresh the [registry](/reference/system-registry) if the public snapshot changed.
+
+---
+
+<!-- source-page: app/automation/scheduling/page.mdx | route: https://superagents-docs.vercel.app/automation/scheduling -->
+
+Source page: [Scheduling](https://superagents-docs.vercel.app/automation/scheduling)
+
+# Scheduling
+
+## Choose the owner
+
+| Requirement | Owner |
+|---|---|
+| Continue or revisit the current Codex task | Codex scheduled task |
+| Persistent message delivery or local operational schedule | Hermes cron |
+| Repository test, release, or security gate | GitHub Actions |
+| Host daemon lifecycle | Launch service |
+| Automation contract or cross-system evidence | Context |
+
+## Before enabling a schedule
+
+1. Run the action manually with representative input.
+2. Declare its action class and approval class.
+3. Define destination, timeout, retry, duplicate-suppression, and failure behavior.
+4. Add an independent proof signal.
+5. Confirm recovery and disable paths.
+
+Stay quiet when unchanged state is expected. Notify on meaningful change, completion, failure, or required operator action.
+
+---
+
+<!-- source-page: app/capabilities/page.mdx | route: https://superagents-docs.vercel.app/capabilities -->
+
+Source page: [Capabilities](https://superagents-docs.vercel.app/capabilities)
+
+# Capabilities
+
+Capabilities are reusable execution surfaces. Choose the smallest one that owns the required context and no more authority than the task needs.
+
+| Surface | Use it for | Avoid using it as |
+|---|---|---|
+| Agent or subagent | A bounded role or independent workstream | A second source of truth |
+| Skill | A repeatable workflow with instructions and assets | A catch-all personality |
+| Command | A concise, explicit entry point | Hidden policy |
+| Plugin | A managed bundle of skills, connectors, or UI | Implicit authorization |
+| MCP service | Structured access to an external or local capability | A credential store |
+| Browser or computer use | User-visible interaction and verification | Bulk structured data processing |
+
+Capability definitions should state triggers, inputs, outputs, permissions, and proof expectations.
+
+Browse the dated [Capability Inventory](/reference/capability-inventory) for the complete sanitized catalog and exact counting rules.
+
+---
+
+<!-- source-page: app/capabilities/agents-subagents/page.mdx | route: https://superagents-docs.vercel.app/capabilities/agents-subagents -->
+
+Source page: [Agents & Subagents](https://superagents-docs.vercel.app/capabilities/agents-subagents)
+
+# Agents & Subagents
+
+An agent packages a role, context boundary, and tool policy. A subagent is a bounded delegation from a parent task.
+
+## Runtime models
+
+| Runtime | Delegation model |
+|---|---|
+| Codex | Spawn bounded subagents for independent research, review, or isolated implementation; the parent integrates and closes the loop. |
+| Claude Code | Select specialist agent definitions from the active catalog; commands and plugins may route work further. |
+| Hermes | Choose a persistent profile with an explicit toolset, messaging surface, and scheduler policy. |
+
+## Safe parallelism
+
+- Give each agent a concrete deliverable and clear boundary.
+- Avoid concurrent edits to the same files.
+- Avoid competing control of the same browser or authenticated session.
+- Separate implementation from independent review for consequential work.
+- Keep approval and final evidence responsibility with the orchestrating task.
+
+Catalog counts belong only in the [generated registry](/reference/system-registry).
+
+---
+
+<!-- source-page: app/capabilities/browser-computer-use/page.mdx | route: https://superagents-docs.vercel.app/capabilities/browser-computer-use -->
+
+Source page: [Browser & Computer Use](https://superagents-docs.vercel.app/capabilities/browser-computer-use)
+
+# Browser & Computer Use
+
+Use the narrowest reliable interaction surface.
+
+| Need | Preferred surface |
+|---|---|
+| Structured or bulk service operation | Service API or CLI |
+| Repeatable public-page extraction | Firecrawl or browser automation |
+| User-visible web verification | Chrome |
+| Authenticated desktop UI unavailable elsewhere | Computer use |
+| Project with a documented browser owner | Follow that project's browser protocol |
+
+Chrome is the default browser for automation when control is available. A project may reserve a browser or profile for another operator; project instructions take precedence.
+
+## Safety
+
+- Never store credentials or browser-profile contents in repositories or docs.
+- Separate observation from external mutation.
+- Resolve exact targets before clicks that publish, delete, pay, or message.
+- Verify user-visible results from the rendered surface, including navigation, search, mobile layout, and access control.
+
+---
+
+<!-- source-page: app/capabilities/mcp-tools/page.mdx | route: https://superagents-docs.vercel.app/capabilities/mcp-tools -->
+
+Source page: [MCP & Tools](https://superagents-docs.vercel.app/capabilities/mcp-tools)
+
+# MCP & Tools
+
+Model Context Protocol services expose structured capabilities to one or more runtimes. Tool availability and authorization are separate questions.
+
+## Shared Firecrawl broker
+
+Firecrawl is the shared local web research service for Codex, Claude, Gemini, Grok, and Hermes-compatible workflows. Clients use one broker endpoint on the local machine rather than resolving a secret independently for every runtime.
+
+Operational rule: check broker status first and start it only when stopped. Treat one 1Password authorization as a session-wide budget; batch the work and never scatter exploratory secret reads.
+
+## Other tool classes
+
+Codex currently has configured services for structured documents, terminal commerce, design, persistent code execution, computer use, presentation work, and web research. The owning configuration is authoritative; the [registry](/reference/system-registry) publishes only sanitized counts.
+
+## Tool contract
+
+For every tool, know:
+
+- what data leaves the machine;
+- which account or connector authorizes it;
+- whether it reads, writes, notifies, spends, or deletes;
+- what evidence confirms the result;
+- how to revoke or recover it.
+
+---
+
+<!-- source-page: app/capabilities/skills-plugins/page.mdx | route: https://superagents-docs.vercel.app/capabilities/skills-plugins -->
+
+Source page: [Skills & Plugins](https://superagents-docs.vercel.app/capabilities/skills-plugins)
+
+# Skills & Plugins
+
+A **skill** is a focused, reusable workflow: instructions, references, scripts, and optional assets. A **plugin** is a managed package that may expose several skills, tools, connectors, or application integrations.
+
+## Where they live
+
+- Personal skills are Git-backed and shared deliberately across compatible runtimes.
+- Runtime-native skills and agents remain with their owning runtime.
+- Managed plugin caches are installation artifacts, not editing locations.
+- Compatibility copies are not automatically active.
+
+## Maintenance rules
+
+1. Read the selected skill completely before acting.
+2. Reuse provided scripts and assets instead of re-creating them.
+3. Keep one canonical definition and document intentional adapters.
+4. Verify the consuming runtime after an update.
+5. Record volatile version and inventory data once in the [system registry](/reference/system-registry).
+
+Duplicate-looking manifests may be different installed plugin versions or nested packs. Inventory reports must define exactly what they count.
+
+The [Capability Inventory](/reference/capability-inventory) lists resolvable personal skills, managed plugins, Claude skills and plugins, and categorized Hermes skills.
+
+---
+
+<!-- source-page: app/context-memory/page.mdx | route: https://superagents-docs.vercel.app/context-memory -->
+
+Source page: [Context & Memory](https://superagents-docs.vercel.app/context-memory)
+
+# Context & Memory
+
+Context is information supplied to the current run. Memory is information a runtime retains or retrieves across runs. Neither category is automatically authoritative.
+
+## Context sources
+
+- Current prompt, conversation, or scheduled payload
+- Global and project instruction chains
+- Repository files and live working state
+- Selected agent, skill, plugin, or profile instructions
+- Curated vault material
+- Runtime memory and conversation history
+- Tool results and current external evidence
+
+The Context control plane owns fleet inventory, automation contracts, and evidence state. The knowledge vault owns curated durable context. Runtime-local memory is useful but must yield to an owning source when facts conflict.
+
+See [Context Layering](/context-memory/layering) and [Storage Model](/context-memory/storage).
+
+---
+
+<!-- source-page: app/context-memory/layering/page.mdx | route: https://superagents-docs.vercel.app/context-memory/layering -->
+
+Source page: [Context Layering](https://superagents-docs.vercel.app/context-memory/layering)
+
+# Context Layering
+
+Apply context from broad policy to specific task evidence.
+
+```text
+User intent
+  └─ global operating policy
+      └─ repository or project instructions
+          └─ runtime identity and selected capability
+              └─ memory and curated knowledge
+                  └─ live repository and external evidence
+```
+
+More specific instructions refine broader ones unless they violate a higher-priority safety or authority boundary. Live evidence corrects stale narrative context; it does not erase the need to update the owning record.
+
+## Runtime entry points
+
+- Codex uses an `AGENTS.md` chain, thread history, memories, and selected skills or plugins.
+- Claude Code uses a `CLAUDE.md` chain, agents, commands, skills, plugins, rules, hooks, and session memory.
+- Hermes combines its soul, selected profile, memory, skills, message context, and scheduler payload.
+- Companion CLIs use their own instruction and connector configuration plus the current repository.
+
+Never assume two runtime directories are synchronized merely because their content is similar.
+
+---
+
+<!-- source-page: app/context-memory/storage/page.mdx | route: https://superagents-docs.vercel.app/context-memory/storage -->
+
+Source page: [Storage Model](https://superagents-docs.vercel.app/context-memory/storage)
+
+# Storage Model
+
+Every durable information type has one preferred home.
+
+| Store | Purpose |
+|---|---|
+| Private knowledge vault | Curated knowledge, decisions, goals, identity, and system guidance |
+| GitHub | Code, infrastructure, documentation, review, and delivery history |
+| Google Drive | Designated files and structured working data |
+| iCloud | Apple-native personal data |
+| Internal local storage | Active repositories, runtime state, caches, and transient work |
+| External storage | Cold backup snapshots only, while mounted |
+| 1Password | Credentials and secret references |
+
+Active systems must not depend on an external disk or a compatibility symlink to one. Clone missing repositories from GitHub onto internal storage.
+
+Secrets never belong in the vault, source repository, local documentation, or ad hoc plaintext environment files. Configuration should retain only managed references.
+
+---
+
+<!-- source-page: app/estate/page.mdx | route: https://superagents-docs.vercel.app/estate -->
+
+Source page: [Estate Coverage](https://superagents-docs.vercel.app/estate)
+
+# Estate Coverage
+
+> Generated from `config/estate-coverage.json`. The GitHub estate scan ran **September 8, 2026 at 9:26 p.m.**.
+
+**Scope:** All repositories accessible to the authenticated GitHub account through ownership, organization membership, or collaboration were scanned by tree and selected documentation/configuration surfaces. Results published here are sanitized; private names, private content, and credentials were not copied.
+
+This section answers four separate questions without conflating them: what exists, which agentic components are discoverable, what has documentation, and what was directly verified on a device.
+
+| Coverage dimension | Count |
+|---|---:|
+| Accessible GitHub repositories | 147 |
+| Owners and organizations represented | 4 |
+| Active repositories | 119 |
+| Archived repositories | 28 |
+| Non-empty repository trees scanned | 139 |
+| Empty repositories | 8 |
+| Repository scan failures | 0 |
+| Declaration files selected | 591 |
+| Declaration files inspected | 591 |
+| Declaration file read failures | 0 |
+| Agentic component classes | 22 |
+| Declared operating devices | 3 |
+| Directly verified devices | 1 |
+
+## Navigate the estate
+
+- [Agentic Components](/estate/components) — the complete repository-discoverable component taxonomy, from instructions and skills through orchestration and proof
+- [Repositories](/estate/repositories) — every accessible GitHub repository, local checkout coverage, and documentation signals
+- [Devices & Hosts](/estate/devices) — which machines are declared versus directly attested
+- [Data Sources & Integrations](/estate/data-sources) — canonical storage surfaces and repository-level service fingerprints
+
+## What “complete” means here
+
+- **Repository-complete:** all 147 repositories accessible through ownership, organization membership, or collaboration were enumerated; 139 non-empty trees were scanned and 8 repositories were empty.
+- **Current-tree sanitized:** private names, private content, credentials, customer records, messages, and financial data were not copied into the current published tree. Legacy Git history predates these controls and is tracked as a hardening gap.
+- **Device-honest:** only the main Mac mini is directly verified. The other declared devices remain visible as coverage gaps until the same audit runs there.
+- **Evidence-aware:** a file or service reference proves discoverability, not correctness, authorization, freshness, or documentation quality.
+
+---
+
+<!-- source-page: app/estate/components/page.mdx | route: https://superagents-docs.vercel.app/estate/components -->
+
+Source page: [Agentic Components](https://superagents-docs.vercel.app/estate/components)
+
+# Agentic Components
+
+> Snapshot: **September 8, 2026 at 9:26 p.m.**. Generated from high-confidence agentic repositories; candidate path categories intentionally overlap.
+
+This taxonomy lists every class of repository-discoverable agentic component the scanner recognizes. It covers declarative policy, executable capabilities, control-plane wiring, context, orchestration, scheduled work, integrations, and verification evidence.
+
+| Component class | What belongs here | Agentic repos | Candidate files | Active repos | Active candidate files | Public evidence samples |
+|---|---|---:|---:|---:|---:|---|
+| Agent instruction layers | Repository or directory policy files consumed by agent runtimes. | 65 | 109 | 58 | 94 | `GuillaumeRacine/limitless_MVP:CLAUDE.md`<br />`GuillaumeRacine/ensemble_prototypes:CLAUDE.md`<br />`GuillaumeRacine/DN_Model:AGENTS.md` |
+| Agent and subagent definitions | Named agent, subagent, coach, or specialist definition files. | 19 | 291 | 17 | 248 | `GuillaumeRacine/ensemble_prototypes:.claude/agents/idea.md`<br />`GuillaumeRacine/ensemble_prototypes:.claude/agents/launch.md`<br />`GuillaumeRacine/ensemble_prototypes:.claude/agents/research.md` |
+| Skill manifests | SKILL.md packages and repository-owned skill definitions. | 13 | 795 | 13 | 795 | `GuillaumeRacine/KAI_Ensembl3:skills/Agents/SKILL.md`<br />`GuillaumeRacine/KAI_Ensembl3:skills/Browser/SKILL.md`<br />`GuillaumeRacine/KAI_Ensembl3:skills/CORE/SKILL.md` |
+| Commands and slash actions | Reusable command definitions exposed to an agent runtime. | 12 | 222 | 11 | 213 | `GuillaumeRacine/present-agent2:.claude/commands/README.md`<br />`GuillaumeRacine/present-agent2:.claude/commands/build.md`<br />`GuillaumeRacine/present-agent2:.claude/commands/docs.md` |
+| Prompt definitions | Repository-owned prompt templates, system prompts, and prompt packs. | 6 | 15 | 6 | 15 | `GuillaumeRacine/hermes-agent:optional-skills/creative/baoyu-article-illustrator/prompts/system.md` |
+| MCP definitions | MCP server, client, tool, and configuration definitions. | 11 | 86 | 11 | 86 | `GuillaumeRacine/Tao-promotion:mcp-server/README.md`<br />`GuillaumeRacine/Tao-promotion:mcp-server/package-lock.json`<br />`GuillaumeRacine/Tao-promotion:mcp-server/package.json` |
+| Plugin manifests | Agent-runtime plugin descriptors and repository-owned plugin packages. | 8 | 105 | 8 | 105 | `GuillaumeRacine/ralph-claud-code:.claude-plugin/plugin.json`<br />`GuillaumeRacine/hermes-agent:plugins/browser/browser_use/plugin.yaml`<br />`GuillaumeRacine/hermes-agent:plugins/browser/browserbase/plugin.yaml` |
+| Hooks and policy rules | Lifecycle hooks, guards, routing rules, and runtime policy modules. | 4 | 9 | 2 | 7 | `GuillaumeRacine/present-agent2:.claude/hooks/user-prompt-submit.sh` |
+| Automations and schedules | GitHub workflows, cron definitions, automations, and scheduled job declarations. | 22 | 143 | 21 | 141 | `GuillaumeRacine/DN_Model:.github/workflows/ci.yml`<br />`GuillaumeRacine/defi-pool-dashboard:jobs/README.md`<br />`GuillaumeRacine/defi-pool-dashboard:jobs/package-lock.json` |
+| Profiles and personas | Runtime profiles, personas, souls, and role definitions. | 8 | 2,235 | 7 | 2,234 | `GuillaumeRacine/present-agent2:src/test/personas/test-personas.ts`<br />`GuillaumeRacine/hermes-agent:apps/desktop/src/app/profiles/create-profile-dialog.tsx`<br />`GuillaumeRacine/hermes-agent:apps/desktop/src/app/profiles/delete-profile-dialog.tsx` |
+| Context and memory assets | Curated context, memory, knowledge, and retrieval declarations used by agents. | 13 | 85 | 10 | 82 | `GuillaumeRacine/emailLLM2:app/api/ai/context/route.ts`<br />`GuillaumeRacine/crypto-web-monitor:Present-Agent/src/web/components/memory/MemoryDrawer.tsx`<br />`GuillaumeRacine/gmail-llm:app/api/ai/context/route.ts` |
+| Orchestration graphs and pipelines | Multi-step agent graphs, pipelines, and workflow orchestration definitions. | 25 | 474 | 23 | 469 | `GuillaumeRacine/DN_Model:.github/workflows/ci.yml`<br />`GuillaumeRacine/Transcripts_Automated:.github/workflows/backfill.yml`<br />`GuillaumeRacine/Transcripts_Automated:.github/workflows/schedule.yml` |
+| Evaluation, observability, and proof | Evals, evidence contracts, proof bundles, audits, and agent observability assets. | 15 | 346 | 15 | 346 | `GuillaumeRacine/hermes-agent:docs/observability/README.md`<br />`GuillaumeRacine/hermes-agent:plugins/observability/langfuse/README.md`<br />`GuillaumeRacine/hermes-agent:plugins/observability/langfuse/__init__.py` |
+| Tools and connectors | Repository-owned tools, connectors, integrations, and callable capability definitions. | 10 | 655 | 10 | 655 | `GuillaumeRacine/defi-analytics-dashboard:src/integration/data_sources.py`<br />`GuillaumeRacine/KAI_Ensembl3:skills/Agents/Tools/AgentFactory.ts`<br />`GuillaumeRacine/KAI_Ensembl3:skills/Agents/Tools/BarRaiser.ts` |
+| Models, providers, and routing | Model catalogs, provider adapters, routing policies, and fallback declarations. | 5 | 91 | 5 | 91 | `GuillaumeRacine/hermes-agent:apps/desktop/src/components/assistant-ui/embeds/providers/detect.test.ts`<br />`GuillaumeRacine/hermes-agent:apps/desktop/src/components/assistant-ui/embeds/providers/index.ts`<br />`GuillaumeRacine/hermes-agent:apps/desktop/src/components/assistant-ui/embeds/providers/instagram.ts` |
+| Retrieval and indexes | Retrieval pipelines, vector/index definitions, embeddings, and search assets. | 5 | 31 | 4 | 30 | `GuillaumeRacine/tao-substack-daily-notes:src/retrieval/vector_db.py`<br />`GuillaumeRacine/MILA-Social-Graph:scripts/search/chat_agent.py`<br />`GuillaumeRacine/MILA-Social-Graph:scripts/search/chat_cli.py` |
+| State and persistence | Agent state, checkpoints, session stores, and persistence declarations. | 10 | 489 | 9 | 487 | `GuillaumeRacine/present-agent2:docs/archive/sessions/DOCUMENTATION_CLEANUP_SUMMARY.md`<br />`GuillaumeRacine/present-agent2:docs/archive/sessions/IMPROVEMENTS_SUMMARY.md`<br />`GuillaumeRacine/hermes-agent:apps/desktop/src/app/session/hooks/use-context-suggestions.ts` |
+| Interfaces and delivery channels | Agent-facing applications, channel adapters, transports, and delivery surfaces. | 6 | 57 | 5 | 52 | `GuillaumeRacine/crypto-web-monitor:Present-Agent/src/server/adapters/fivedb/catalog.postgres.ts`<br />`GuillaumeRacine/crypto-web-monitor:Present-Agent/src/server/adapters/fivedb/events.redpanda.ts`<br />`GuillaumeRacine/crypto-web-monitor:Present-Agent/src/server/adapters/fivedb/graph.neo4j.ts` |
+| Permissions and security contracts | Authentication, authorization, permission, secret-reference, and safety contracts. | 20 | 104 | 15 | 87 | `GuillaumeRacine/roadie-music-collab:src/app/api/auth/logout/route.ts`<br />`GuillaumeRacine/roadie-music-collab:src/app/api/dropbox/auth/route.ts`<br />`GuillaumeRacine/emailLLM2:app/api/auth/callback/route.ts` |
+| Runtime and deployment definitions | Containers, hosting, service, worker, and runtime deployment declarations. | 30 | 133 | 25 | 79 | `GuillaumeRacine/defi-analytics-dashboard:eth-chart/vercel.json`<br />`GuillaumeRacine/roadie-music-collab:vercel.json`<br />`GuillaumeRacine/defi-pool-dashboard:vercel.json` |
+| Schemas and contracts | Typed schemas, protocols, event contracts, and structured input/output definitions. | 14 | 51 | 14 | 51 | `GuillaumeRacine/defi-pool-dashboard:src/app/protocols/page.tsx`<br />`GuillaumeRacine/Mila_Agent021:schemas/artifact.schema.json`<br />`GuillaumeRacine/Mila_Agent021:schemas/assumption.schema.json` |
+| Templates and artifacts | Reusable agent templates, artifact specifications, and output-format definitions. | 19 | 960 | 19 | 960 | `GuillaumeRacine/KAI_Ensembl3:skills/Prompting/Templates/README.md`<br />`GuillaumeRacine/Mila_Agent021:templates/decision_checkpoint.md`<br />`GuillaumeRacine/Mila_Agent021:templates/experiment_card.md` |
+
+## How to read the inventory
+
+- Counts are candidate structural signals inside repositories first classified as agentic by strong signals such as agent instructions, definitions, skills, commands, prompts, MCPs, plugins, profiles, or repository identity.
+- Samples make representative public matches reviewable; private paths remain private. Path heuristics can still misclassify a file or miss an unconventional layout.
+- Counts do not claim that a component is enabled, current, authorized, or healthy.
+- A file can belong to more than one class, so rows must not be summed.
+- Archived repositories remain visible in the all-repository columns; active columns isolate the operating estate.
+- Runtime-installed capabilities that are not committed to a repository are covered separately by the [Capability Inventory](/reference/capability-inventory).
+
+Use [Repository Coverage](/estate/repositories) for estate-wide documentation gaps and [Systems Registry](/reference/system-registry) for the currently verified operating systems.
+
+---
+
+<!-- source-page: app/estate/data-sources/page.mdx | route: https://superagents-docs.vercel.app/estate/data-sources -->
+
+Source page: [Data Sources & Integrations](https://superagents-docs.vercel.app/estate/data-sources)
+
+# Data Sources & Integrations
+
+> Snapshot: **September 8, 2026 at 9:26 p.m.**. This page distinguishes canonical data ownership from references found in repository declarations.
+
+## Canonical source surfaces
+
+| Source | Role | Audit state | Evidence boundary |
+|---|---|---|---|
+| GitHub | Code and shipped documentation | live-scanned | 147 accessible repositories across 4 owners or organizations; 139 trees scanned |
+| Context control plane | Automation registry and evidence | live-local | Generated inventory, contracts, and fleet evidence |
+| Knowledge vault | Curated context and durable knowledge | live-local | Private Git-backed vault; content remains private |
+| Hermes state | Profiles, schedules, skills, and delivery state | live-local | 82 jobs; 61 enabled; 21 paused |
+| Google Drive | Default file and data store | policy-declared · not live-listed | Connector/API or web is authoritative; Drive Desktop and rclone are unavailable on this host |
+| iCloud | Apple-native data | host-visible | 18 top-level host-visible directories; content not enumerated |
+| 1Password | Credentials | policy-declared · intentionally not enumerated | Only references and access contracts may be documented |
+| External SSD | Cold backup and archive | mounted · excluded from active scan | Not an agent-runtime or repository dependency; canonical policy retains a studio-mini active-Ableton exception |
+| Vercel | Documentation deployment | not verified for this snapshot | Production verification is performed after deployment and recorded in GitHub against the commit and deployment |
+
+## Integration fingerprints across active repositories
+
+The scanner inspected 591 selected README, package, environment-example, architecture, and integration files. Counts show how many active repositories reference each integration class.
+
+| Integration class | Active repository references |
+|---|---:|
+| anthropic | 75 |
+| github | 75 |
+| vercel | 45 |
+| google-services | 32 |
+| openai | 31 |
+| shopify | 31 |
+| notion | 21 |
+| slack | 20 |
+| postgres | 18 |
+| sqlite | 16 |
+| x-twitter | 16 |
+| 1password | 15 |
+| substack | 13 |
+| resend | 11 |
+| telegram | 11 |
+| gemini | 10 |
+| ghost | 8 |
+| stripe | 8 |
+| spotify | 7 |
+| sentry | 6 |
+| supabase | 6 |
+| dropbox | 5 |
+| firecrawl | 5 |
+| monarch | 5 |
+| mongodb | 4 |
+| discord | 3 |
+| redis-upstash | 3 |
+| clerk | 2 |
+
+A reference is a discovery signal, not proof that credentials exist, data is fresh, or the integration is healthy. Operational status remains with the owning repository, provider, or control-plane evidence.
+
+## Protected boundaries
+
+- A repository tree and selected declaration files prove discoverability, not documentation quality or runtime correctness.
+- The studio Mac mini and MacBook remain policy-declared until the same verifier runs on those hosts.
+- Google Drive, iCloud content, 1Password items, customer data, inboxes, and financial records were not content-scanned.
+- Integration fingerprints indicate references in active repositories; they do not prove that credentials are configured or the service is healthy.
+- Agentic component rows are candidate path signals within high-confidence agentic repositories. Categories intentionally overlap and path matching can still produce false positives or miss unconventional layouts.
+- The current published tree is sanitized. Legacy public Git history predates these controls and remains a known privacy-hardening gap tracked in GitHub issue #4.
+
+---
+
+<!-- source-page: app/estate/devices/page.mdx | route: https://superagents-docs.vercel.app/estate/devices -->
+
+Source page: [Devices & Hosts](https://superagents-docs.vercel.app/estate/devices)
+
+# Devices & Hosts
+
+> Snapshot: **September 8, 2026 at 9:26 p.m.**. Device declarations were parsed from the canonical storage policy revision `f6891ce304b19753`; verification state comes from this audit run.
+
+| Device | Role | Verification | Evidence |
+|---|---|---|---|
+| Mac mini (main) | Primary work + agents | directly verified | Canonical policy: Vault, active code/runtimes on internal storage; SSD optional. Local repositories, runtime configuration, Hermes scheduler state, and source availability were inspected on this host. |
+| Mac mini (studio) | Music recording | policy-declared · not remotely attested | Canonical policy: Audio sessions, no GDrive needed, no SSD. The same policy explicitly excepts active Ableton sessions, which may use the studio SSD as the fast working disk. This audit did not execute on that host. |
+| MacBook | Mobile work | policy-declared · not remotely attested | Canonical policy: Vault, GDrive (Stream or selective Mirror — saves disk), code repos. This audit did not execute on that host. |
+
+## Coverage rule
+
+A device is **directly verified** only when the estate and runtime checks execute on that host. Git synchronization or a policy entry does not prove installed versions, local skills, active services, browser sessions, or scheduler state.
+
+The main Mac mini currently owns the live runtime snapshot. The studio Mac mini and MacBook are documented so they cannot disappear from the architecture, but their agentic configuration is not claimed as current.
+
+## Cross-device source ownership
+
+- GitHub synchronizes code and shipped documentation.
+- The private vault synchronizes curated knowledge through Git.
+- Google Drive is the device-independent source for files and datasets.
+- iCloud owns Apple-native data.
+- 1Password owns credentials.
+- Local runtime caches, sessions, and installed versions remain device-specific and require host-level verification.
+- The external SSD is cold storage for normal agent and repository operation. The canonical policy explicitly retains one exception: active Ableton sessions on the studio Mac mini may use its SSD as a fast working disk.
+
+---
+
+<!-- source-page: app/estate/repositories/page.mdx | route: https://superagents-docs.vercel.app/estate/repositories -->
+
+Source page: [Repository Coverage](https://superagents-docs.vercel.app/estate/repositories)
+
+# Repository Coverage
+
+> Snapshot: **September 8, 2026 at 9:26 p.m.**. Generated from the authenticated GitHub account inventory and repository trees.
+
+## GitHub estate
+
+| Measurement | Count |
+|---|---:|
+| Total accessible | 147 |
+| Owners and organizations | 4 |
+| Active | 119 |
+| Archived | 28 |
+| Private | 81 |
+| Public | 66 |
+| Forks | 1 |
+| Accounted for | 147 |
+| Non-empty trees scanned | 139 |
+| Empty repositories | 8 |
+| Scan failures | 0 |
+| Truncated trees | 0 |
+| Declaration files selected | 591 |
+| Declaration files inspected | 591 |
+| Declaration file read failures | 0 |
+
+All 147 repositories accessible through ownership, organization membership, or collaboration were accounted for. The difference between total repositories and scanned trees is explained by empty repositories, not silent scan failures.
+
+## Documentation signals
+
+| Signal | Count |
+|---|---:|
+| Repositories with documentation | 132 |
+| Repositories with a root README | 123 |
+| Repositories with a docs directory | 50 |
+| Repositories with agent instructions | 65 |
+| Repositories with GitHub workflows | 21 |
+| Documentation files discovered | 9,793 |
+| Agentic repositories | 79 |
+| Agentic repositories with instructions | 65 |
+| Active repositories with documentation | 109 |
+| Active repositories with a root README | 101 |
+| Active repositories with agent instructions | 58 |
+| Active agentic repositories | 69 |
+| Active agentic repositories with instructions | 58 |
+
+These are structural signals. A README or instructions file can still be stale, incomplete, or incorrect; each active project remains responsible for its own source-of-truth documentation and deployment proof.
+
+## Public repositories
+
+Public repository names link directly to GitHub.
+
+| Repository | Visibility | Lifecycle | Tree | Docs | Agentic | Instructions | Component classes |
+|---|---|---|---|---|---|---|---:|
+| [aadityarajkumawat/gift_assistant_ui](https://github.com/aadityarajkumawat/gift_assistant_ui) | public | active | tree-scanned | yes | no | not-applicable | 1 |
+| [GuillaumeRacine/-Limitless](https://github.com/GuillaumeRacine/-Limitless) | public | archived | tree-scanned | yes | no | not-applicable | 0 |
+| [GuillaumeRacine/AI-social-graph](https://github.com/GuillaumeRacine/AI-social-graph) | public | active | tree-scanned | yes | yes | present | 1 |
+| [GuillaumeRacine/Audio-transcriber](https://github.com/GuillaumeRacine/Audio-transcriber) | public | active | tree-scanned | yes | no | not-applicable | 0 |
+| [GuillaumeRacine/bcorp_index](https://github.com/GuillaumeRacine/bcorp_index) | public | archived | tree-scanned | yes | no | not-applicable | 6 |
+| [GuillaumeRacine/bookfinder](https://github.com/GuillaumeRacine/bookfinder) | public | archived | tree-scanned | yes | no | not-applicable | 1 |
+| [GuillaumeRacine/brave-capture](https://github.com/GuillaumeRacine/brave-capture) | public | active | tree-scanned | yes | no | not-applicable | 0 |
+| [GuillaumeRacine/brave-capture-v2](https://github.com/GuillaumeRacine/brave-capture-v2) | public | active | tree-scanned | yes | yes | present | 2 |
+| [GuillaumeRacine/Centris.ca](https://github.com/GuillaumeRacine/Centris.ca) | public | active | tree-scanned | yes | no | not-applicable | 0 |
+| [GuillaumeRacine/cli-about-me](https://github.com/GuillaumeRacine/cli-about-me) | public | active | tree-scanned | yes | no | not-applicable | 1 |
+| [GuillaumeRacine/crypto-web-monitor](https://github.com/GuillaumeRacine/crypto-web-monitor) | public | active | tree-scanned | yes | yes | present | 5 |
+| [GuillaumeRacine/dashboard_app](https://github.com/GuillaumeRacine/dashboard_app) | public | active | tree-scanned | yes | no | not-applicable | 1 |
+| [GuillaumeRacine/datavault](https://github.com/GuillaumeRacine/datavault) | public | active | tree-scanned | yes | no | not-applicable | 1 |
+| [GuillaumeRacine/defi-analytics-dashboard](https://github.com/GuillaumeRacine/defi-analytics-dashboard) | public | active | tree-scanned | yes | yes | present | 3 |
+| [GuillaumeRacine/defi-pool-dashboard](https://github.com/GuillaumeRacine/defi-pool-dashboard) | public | active | tree-scanned | yes | yes | present | 4 |
+| [GuillaumeRacine/defi-portfolio-dashboard](https://github.com/GuillaumeRacine/defi-portfolio-dashboard) | public | active | tree-scanned | yes | no | not-applicable | 1 |
+| [GuillaumeRacine/defi-portfolio-tracker](https://github.com/GuillaumeRacine/defi-portfolio-tracker) | public | active | tree-scanned | no | no | not-applicable | 0 |
+| [GuillaumeRacine/DN_Model](https://github.com/GuillaumeRacine/DN_Model) | public | active | tree-scanned | yes | yes | present | 3 |
+| [GuillaumeRacine/documentation](https://github.com/GuillaumeRacine/documentation) | public | active | tree-scanned | yes | no | not-applicable | 0 |
+| [GuillaumeRacine/emailLLM2](https://github.com/GuillaumeRacine/emailLLM2) | public | archived | tree-scanned | yes | yes | **gap** | 2 |
+| [GuillaumeRacine/ensemble_prototypes](https://github.com/GuillaumeRacine/ensemble_prototypes) | public | active | tree-scanned | yes | yes | present | 2 |
+| [GuillaumeRacine/FounderMTL](https://github.com/GuillaumeRacine/FounderMTL) | public | active | tree-scanned | yes | yes | present | 3 |
+| [GuillaumeRacine/founders_transcripts_RAG](https://github.com/GuillaumeRacine/founders_transcripts_RAG) | public | active | tree-scanned | yes | no | not-applicable | 1 |
+| [GuillaumeRacine/founders.rent](https://github.com/GuillaumeRacine/founders.rent) | public | archived | tree-scanned | yes | no | not-applicable | 0 |
+| [GuillaumeRacine/gmail-llm](https://github.com/GuillaumeRacine/gmail-llm) | public | archived | tree-scanned | yes | yes | present | 3 |
+| [GuillaumeRacine/gmail-notion-drive-organizer](https://github.com/GuillaumeRacine/gmail-notion-drive-organizer) | public | archived | tree-scanned | yes | no | not-applicable | 0 |
+| [GuillaumeRacine/headless-shopify-template](https://github.com/GuillaumeRacine/headless-shopify-template) | public | active | tree-scanned | yes | yes | present | 1 |
+| [GuillaumeRacine/hermes-agent](https://github.com/GuillaumeRacine/hermes-agent) | public | active | tree-scanned | yes | yes | present | 18 |
+| [GuillaumeRacine/jobster](https://github.com/GuillaumeRacine/jobster) | public | archived | tree-scanned | yes | no | not-applicable | 2 |
+| [GuillaumeRacine/KAI_Ensembl3](https://github.com/GuillaumeRacine/KAI_Ensembl3) | public | active | tree-scanned | yes | yes | **gap** | 6 |
+| [GuillaumeRacine/Kindle-to-pdf](https://github.com/GuillaumeRacine/Kindle-to-pdf) | public | active | tree-scanned | yes | no | not-applicable | 2 |
+| [GuillaumeRacine/limitless_MVP](https://github.com/GuillaumeRacine/limitless_MVP) | public | active | tree-scanned | yes | yes | present | 1 |
+| [GuillaumeRacine/Media-Minivault](https://github.com/GuillaumeRacine/Media-Minivault) | public | active | tree-scanned | yes | yes | present | 1 |
+| [GuillaumeRacine/Mila_Agent021](https://github.com/GuillaumeRacine/Mila_Agent021) | public | active | tree-scanned | yes | yes | present | 5 |
+| [GuillaumeRacine/MILA-Social-Graph](https://github.com/GuillaumeRacine/MILA-Social-Graph) | public | active | tree-scanned | yes | yes | present | 4 |
+| [GuillaumeRacine/MiniVault](https://github.com/GuillaumeRacine/MiniVault) | public | active | tree-scanned | yes | yes | present | 3 |
+| [GuillaumeRacine/ninja-list-vf](https://github.com/GuillaumeRacine/ninja-list-vf) | public | archived | tree-scanned | yes | no | not-applicable | 0 |
+| [GuillaumeRacine/NODEJS_Udemy_JSmilga](https://github.com/GuillaumeRacine/NODEJS_Udemy_JSmilga) | public | archived | tree-scanned | no | no | not-applicable | 0 |
+| [GuillaumeRacine/NODEJS-Udemy-Course](https://github.com/GuillaumeRacine/NODEJS-Udemy-Course) | public | archived | empty | no | no | not-applicable | 0 |
+| [GuillaumeRacine/Options](https://github.com/GuillaumeRacine/Options) | public | active | tree-scanned | yes | no | not-applicable | 0 |
+| [GuillaumeRacine/options-trading-dashboard](https://github.com/GuillaumeRacine/options-trading-dashboard) | public | active | tree-scanned | yes | no | not-applicable | 1 |
+| [GuillaumeRacine/Present-Agent-1](https://github.com/GuillaumeRacine/Present-Agent-1) | public | archived | tree-scanned | yes | yes | present | 3 |
+| [GuillaumeRacine/present-agent-mcp](https://github.com/GuillaumeRacine/present-agent-mcp) | public | active | tree-scanned | yes | yes | **gap** | 1 |
+| [GuillaumeRacine/present-agent2](https://github.com/GuillaumeRacine/present-agent2) | public | archived | tree-scanned | yes | yes | present | 8 |
+| [GuillaumeRacine/present.rocks.final](https://github.com/GuillaumeRacine/present.rocks.final) | public | archived | tree-scanned | yes | no | not-applicable | 0 |
+| [GuillaumeRacine/Products-scrapers](https://github.com/GuillaumeRacine/Products-scrapers) | public | active | tree-scanned | yes | no | not-applicable | 1 |
+| [GuillaumeRacine/prototype-research](https://github.com/GuillaumeRacine/prototype-research) | public | active | empty | no | no | not-applicable | 0 |
+| [GuillaumeRacine/prototype-template](https://github.com/GuillaumeRacine/prototype-template) | public | archived | tree-scanned | yes | no | not-applicable | 0 |
+| [GuillaumeRacine/ralph-claud-code](https://github.com/GuillaumeRacine/ralph-claud-code) | public | active | tree-scanned | yes | yes | **gap** | 2 |
+| [GuillaumeRacine/roadie-music-collab](https://github.com/GuillaumeRacine/roadie-music-collab) | public | active | tree-scanned | yes | yes | present | 3 |
+| [GuillaumeRacine/Scraping-genius](https://github.com/GuillaumeRacine/Scraping-genius) | public | active | tree-scanned | yes | no | not-applicable | 0 |
+| [GuillaumeRacine/semantic](https://github.com/GuillaumeRacine/semantic) | public | archived | empty | no | no | not-applicable | 0 |
+| [GuillaumeRacine/semantic-gpt](https://github.com/GuillaumeRacine/semantic-gpt) | public | archived | empty | no | no | not-applicable | 0 |
+| [GuillaumeRacine/siversdigest](https://github.com/GuillaumeRacine/siversdigest) | public | archived | tree-scanned | yes | no | not-applicable | 0 |
+| [GuillaumeRacine/Social-graph](https://github.com/GuillaumeRacine/Social-graph) | public | active | tree-scanned | yes | no | not-applicable | 0 |
+| [GuillaumeRacine/StockVault](https://github.com/GuillaumeRacine/StockVault) | public | active | tree-scanned | yes | no | not-applicable | 3 |
+| [GuillaumeRacine/superagents](https://github.com/GuillaumeRacine/superagents) | public | active | tree-scanned | yes | yes | present | 4 |
+| [GuillaumeRacine/Tao-promotion](https://github.com/GuillaumeRacine/Tao-promotion) | public | active | tree-scanned | yes | yes | present | 4 |
+| [GuillaumeRacine/tao-substack-daily-notes](https://github.com/GuillaumeRacine/tao-substack-daily-notes) | public | active | tree-scanned | yes | yes | present | 2 |
+| [GuillaumeRacine/TaoBite](https://github.com/GuillaumeRacine/TaoBite) | public | active | tree-scanned | yes | no | not-applicable | 0 |
+| [GuillaumeRacine/terminal-commerce-plugin](https://github.com/GuillaumeRacine/terminal-commerce-plugin) | public | active | tree-scanned | yes | yes | **gap** | 2 |
+| [GuillaumeRacine/transcripts](https://github.com/GuillaumeRacine/transcripts) | public | archived | tree-scanned | yes | no | not-applicable | 0 |
+| [GuillaumeRacine/Transcripts_Automated](https://github.com/GuillaumeRacine/Transcripts_Automated) | public | archived | tree-scanned | yes | yes | present | 4 |
+| [GuillaumeRacine/Transcripts_MVP](https://github.com/GuillaumeRacine/Transcripts_MVP) | public | archived | tree-scanned | yes | no | not-applicable | 1 |
+| [GuillaumeRacine/tunestack-prototype](https://github.com/GuillaumeRacine/tunestack-prototype) | public | active | empty | no | no | not-applicable | 0 |
+| [GuillaumeRacine/vercel-ai-sdk](https://github.com/GuillaumeRacine/vercel-ai-sdk) | public | archived | tree-scanned | yes | yes | **gap** | 0 |
+
+## Private repositories
+
+Private repositories use snapshot-scoped opaque IDs because this source repository is public; their names and URLs are intentionally absent.
+
+| Repository | Visibility | Lifecycle | Tree | Docs | Agentic | Instructions | Component classes |
+|---|---|---|---|---|---|---|---:|
+| `private-001` | private | active | tree-scanned | yes | no | not-applicable | 0 |
+| `private-002` | private | active | tree-scanned | yes | no | not-applicable | 0 |
+| `private-003` | private | active | tree-scanned | no | no | not-applicable | 0 |
+| `private-004` | private | active | tree-scanned | yes | no | not-applicable | 0 |
+| `private-005` | private | active | tree-scanned | no | no | not-applicable | 0 |
+| `private-006` | private | active | tree-scanned | yes | no | not-applicable | 0 |
+| `private-007` | private | active | tree-scanned | yes | no | not-applicable | 0 |
+| `private-008` | private | active | tree-scanned | yes | no | not-applicable | 0 |
+| `private-009` | private | active | tree-scanned | yes | yes | present | 2 |
+| `private-010` | private | active | tree-scanned | yes | yes | **gap** | 3 |
+| `private-011` | private | active | tree-scanned | yes | no | not-applicable | 1 |
+| `private-012` | private | active | tree-scanned | yes | yes | present | 2 |
+| `private-013` | private | archived | tree-scanned | yes | no | not-applicable | 0 |
+| `private-014` | private | active | tree-scanned | yes | no | not-applicable | 2 |
+| `private-015` | private | active | tree-scanned | no | no | not-applicable | 0 |
+| `private-016` | private | active | tree-scanned | yes | yes | present | 10 |
+| `private-017` | private | active | tree-scanned | yes | no | not-applicable | 0 |
+| `private-018` | private | active | tree-scanned | yes | yes | present | 6 |
+| `private-019` | private | active | tree-scanned | no | yes | **gap** | 0 |
+| `private-020` | private | active | tree-scanned | yes | no | not-applicable | 0 |
+| `private-021` | private | active | tree-scanned | yes | yes | present | 7 |
+| `private-022` | private | active | tree-scanned | yes | yes | present | 5 |
+| `private-023` | private | active | tree-scanned | yes | yes | present | 6 |
+| `private-024` | private | active | tree-scanned | yes | no | not-applicable | 2 |
+| `private-025` | private | active | tree-scanned | yes | yes | **gap** | 1 |
+| `private-026` | private | active | tree-scanned | yes | yes | present | 3 |
+| `private-027` | private | active | tree-scanned | yes | yes | present | 8 |
+| `private-028` | private | active | tree-scanned | yes | yes | present | 14 |
+| `private-029` | private | active | tree-scanned | yes | yes | present | 1 |
+| `private-030` | private | active | tree-scanned | yes | yes | present | 6 |
+| `private-031` | private | active | tree-scanned | yes | yes | present | 4 |
+| `private-032` | private | active | tree-scanned | yes | yes | present | 2 |
+| `private-033` | private | active | tree-scanned | yes | yes | present | 1 |
+| `private-034` | private | active | tree-scanned | yes | yes | present | 14 |
+| `private-035` | private | active | tree-scanned | yes | no | not-applicable | 1 |
+| `private-036` | private | active | tree-scanned | yes | yes | **gap** | 1 |
+| `private-037` | private | active | tree-scanned | yes | yes | present | 3 |
+| `private-038` | private | active | tree-scanned | yes | yes | present | 3 |
+| `private-039` | private | active | tree-scanned | yes | yes | **gap** | 2 |
+| `private-040` | private | active | tree-scanned | yes | yes | present | 2 |
+| `private-041` | private | active | tree-scanned | yes | no | not-applicable | 0 |
+| `private-042` | private | active | tree-scanned | yes | yes | present | 7 |
+| `private-043` | private | active | empty | no | no | not-applicable | 0 |
+| `private-044` | private | active | tree-scanned | yes | no | not-applicable | 0 |
+| `private-045` | private | active | tree-scanned | yes | yes | present | 8 |
+| `private-046` | private | active | tree-scanned | yes | no | not-applicable | 3 |
+| `private-047` | private | active | tree-scanned | yes | yes | present | 2 |
+| `private-048` | private | archived | empty | no | no | not-applicable | 0 |
+| `private-049` | private | active | tree-scanned | yes | yes | present | 14 |
+| `private-050` | private | active | tree-scanned | yes | no | not-applicable | 0 |
+| `private-051` | private | active | tree-scanned | yes | no | not-applicable | 0 |
+| `private-052` | private | active | tree-scanned | yes | no | not-applicable | 0 |
+| `private-053` | private | archived | tree-scanned | yes | yes | present | 9 |
+| `private-054` | private | archived | tree-scanned | yes | yes | present | 2 |
+| `private-055` | private | archived | tree-scanned | yes | yes | present | 1 |
+| `private-056` | private | active | tree-scanned | yes | yes | present | 9 |
+| `private-057` | private | active | tree-scanned | yes | yes | present | 14 |
+| `private-058` | private | active | tree-scanned | yes | yes | present | 18 |
+| `private-059` | private | active | empty | no | no | not-applicable | 0 |
+| `private-060` | private | active | tree-scanned | yes | no | not-applicable | 0 |
+| `private-061` | private | active | tree-scanned | yes | yes | present | 1 |
+| `private-062` | private | active | tree-scanned | yes | yes | **gap** | 0 |
+| `private-063` | private | active | tree-scanned | yes | yes | present | 1 |
+| `private-064` | private | archived | tree-scanned | yes | yes | **gap** | 0 |
+| `private-065` | private | active | tree-scanned | yes | yes | present | 2 |
+| `private-066` | private | active | tree-scanned | no | no | not-applicable | 0 |
+| `private-067` | private | active | tree-scanned | yes | yes | present | 8 |
+| `private-068` | private | active | tree-scanned | yes | yes | present | 5 |
+| `private-069` | private | active | tree-scanned | yes | yes | present | 1 |
+| `private-070` | private | active | tree-scanned | yes | yes | present | 4 |
+| `private-071` | private | active | tree-scanned | yes | yes | present | 3 |
+| `private-072` | private | active | tree-scanned | yes | yes | **gap** | 3 |
+| `private-073` | private | active | tree-scanned | yes | no | not-applicable | 1 |
+| `private-074` | private | active | tree-scanned | yes | yes | present | 4 |
+| `private-075` | private | active | tree-scanned | yes | yes | present | 2 |
+| `private-076` | private | active | tree-scanned | yes | yes | present | 3 |
+| `private-077` | private | active | tree-scanned | yes | no | not-applicable | 1 |
+| `private-078` | private | active | tree-scanned | yes | no | not-applicable | 0 |
+| `private-079` | private | active | tree-scanned | yes | yes | present | 10 |
+| `private-080` | private | active | tree-scanned | yes | no | not-applicable | 1 |
+| `private-081` | private | active | tree-scanned | yes | yes | present | 3 |
+
+## Local checkout coverage
+
+| Measurement | Count |
+|---|---:|
+| Checkout directories | 62 |
+| Unique GitHub remotes | 22 |
+| Authenticated-estate GitHub remotes | 16 |
+| Personal-owner GitHub remotes | 16 |
+| External GitHub remotes | 6 |
+| Duplicate/worktree checkout directories | 40 |
+| Personal-owner checkouts outside the internal code root | 2 |
+
+Multiple checkout directories primarily represent worktrees or deliberate parallel work. Remote-only repositories are cloned into internal storage on demand; the external SSD is not an active repository source.
+
+## Material documentation gap
+
+11 active repositories with high-confidence agentic signals do not expose a recognized AGENTS.md, CLAUDE.md, GEMINI.md, GROK.md, or CODEX.md instruction file. The catalog marks every affected row as **gap** without publishing private names.
+
+---
+
+<!-- source-page: app/governance/page.mdx | route: https://superagents-docs.vercel.app/governance -->
+
+Source page: [Governance & Safety](https://superagents-docs.vercel.app/governance)
+
+# Governance & Safety
+
+Governance answers three questions before execution: what may happen, who authorized it, and what proves it happened correctly.
+
+## Action classes
+
+- **Read-only** — inspect local or external state without mutation.
+- **Local write** — modify scoped workspace files or recoverable local state.
+- **Notify** — send a message or alert to another person or channel.
+- **External mutation** — change a cloud service, commerce system, account, or published surface.
+- **Money** — purchase, trade, bill, refund, or change a paid commitment.
+- **Irreversible** — deletion or action that cannot be reliably undone.
+
+Tool access never upgrades an action's approval class. See [Permissions](/governance/permissions) and [Secrets](/governance/secrets).
+
+---
+
+<!-- source-page: app/governance/documentation/page.mdx | route: https://superagents-docs.vercel.app/governance/documentation -->
+
+Source page: [Documentation Governance](https://superagents-docs.vercel.app/governance/documentation)
+
+# Documentation Governance
+
+This portal is a public-source, sanitized map with a second rendered-site access gate. Google authentication on the website does **not** make the repository content confidential. Auth.js accepts only exact allowlisted, Google-verified email addresses and the route proxy rechecks the session email on every protected request. Domain-wide access is not supported. The client-side search index and machine-navigation files remain public assets because they mirror the sanitized source. Robots are instructed not to index the site.
+
+The current-tree publication scan does not sanitize prior commits. Legacy history is a known hardening gap tracked in [GitHub issue #4](https://github.com/GuillaumeRacine/superagents/issues/4) and must not be described as private or clean until that work is complete.
+
+## Publication rule
+
+Never publish credentials, private URLs, personal records, customer data, absolute user paths, active external-disk dependencies, or copy-paste destructive recovery commands.
+
+## Change workflow
+
+1. Correct the owning runtime or repository documentation first.
+2. Update the system and capability JSON registries for changed public facts.
+3. Regenerate the registry pages; never edit them by hand.
+4. Run freshness, route, link, publication, dependency, secret, and production-build checks.
+5. Review the rendered desktop and mobile site, navigation, search, and access gate.
+6. Ship through GitHub and record deployment evidence.
+
+Volatile counts appear once in the [system registry](/reference/system-registry). Narrative pages link there instead of restating them.
+
+---
+
+<!-- source-page: app/governance/naming/page.mdx | route: https://superagents-docs.vercel.app/governance/naming -->
+
+Source page: [Canonical Naming](https://superagents-docs.vercel.app/governance/naming)
+
+# Canonical Naming
+
+One name identifies the documentation umbrella across human-facing and machine-facing surfaces.
+
+## Naming contract
+
+| Surface | Canonical value |
+| --- | --- |
+| Product and system umbrella | **Super Agents** |
+| GitHub repository | `GuillaumeRacine/superagents` |
+| Vercel project | `superagents` |
+| Production website | `superagents-docs.vercel.app` |
+| Environment-variable prefix | `SUPERAGENTS_` |
+
+Use **Super Agents** in prose and interface copy. Use `superagents` where a platform requires a lowercase slug. Hyphenate only when an external platform requires it; do not create a second brand spelling.
+
+## Rename rule
+
+New repositories, deployments, domains, aliases, packages, branches, routes, variables, and documentation titles must follow the canonical values above. Former names belong only in clearly labeled history and must not survive as compatibility aliases unless Gui explicitly asks for one.
+
+Every naming change must verify the current repository, deployment project, production aliases, live metadata, and repository-wide text search before closeout.
+
+---
+
+<!-- source-page: app/governance/permissions/page.mdx | route: https://superagents-docs.vercel.app/governance/permissions -->
+
+Source page: [Permissions](https://superagents-docs.vercel.app/governance/permissions)
+
+# Permissions
+
+| Action | Default handling |
+|---|---|
+| Read scoped files, inspect status, run non-mutating checks | Autonomous |
+| Edit requested workspace files, run tests, create recoverable artifacts | Autonomous within task scope |
+| Commit, push, deploy, and verify a requested coherent change | Autonomous within the delivery contract |
+| Send a routine notification from a preapproved automation | Preapproved playbook required |
+| Change an external service when the requested intent clearly authorizes that class | Inspect or preview, then apply within scope |
+| Purchase, trade, publish to a new audience, disclose private data, or perform irreversible deletion | Explicit operator approval |
+
+## Guardrails
+
+- Resolve the exact target before consequential writes.
+- Prefer preview, dry run, staging, and recoverable operations.
+- Preserve unrelated working changes.
+- Keep deployment verification separate from business-data mutation.
+- Stop when completion requires a new authority or a meaningful expansion of scope.
+
+---
+
+<!-- source-page: app/governance/secrets/page.mdx | route: https://superagents-docs.vercel.app/governance/secrets -->
+
+Source page: [Secrets](https://superagents-docs.vercel.app/governance/secrets)
+
+# Secrets
+
+1Password is the only credential store. Repositories and local configuration keep managed references, never plaintext keys.
+
+## Session discipline
+
+Treat one 1Password authorization as a session-wide budget:
+
+1. Plan every required secret read.
+2. Resolve them in one deliberate operation.
+3. Keep values only in process memory for the active task.
+4. Never print values into logs, prompts, documentation, or shell history.
+5. If authorization expires, stop and request one new approval instead of triggering repeated prompts.
+
+Shared services such as the Firecrawl broker centralize credential resolution so multiple clients do not create multiple secret prompts.
+
+Secret scanning is part of this portal's CI, but scanning is a backstop—not permission to publish sensitive configuration.
+
+---
+
+<!-- source-page: app/recovery/page.mdx | route: https://superagents-docs.vercel.app/recovery -->
+
+Source page: [Recovery & Rebuild](https://superagents-docs.vercel.app/recovery)
+
+# Recovery & Rebuild
+
+Super Agents is recoverable when durable state stays in GitHub, managed cloud stores, the private knowledge vault, and 1Password references.
+
+This portal is the recovery map, not the backup. Start with [Disaster Rebuild Readiness](/recovery/disaster-rebuild) before wiping, replacing, or restoring a device.
+
+## Recovery order
+
+1. Restore the host and approved package managers.
+2. Authenticate GitHub and 1Password.
+3. Clone active repositories to internal storage.
+4. Restore non-secret runtime configuration and managed secret references.
+5. Install runtimes and shared services.
+6. Restore schedulers disabled, validate manually, then enable deliberately.
+7. Regenerate the Context inventory and verify critical user-visible paths.
+
+Prefer reversible repair and exact targets. Recovery documentation should describe desired state and validation, not publish dangerous recursive deletion shortcuts.
+
+---
+
+<!-- source-page: app/recovery/disaster-rebuild/page.mdx | route: https://superagents-docs.vercel.app/recovery/disaster-rebuild -->
+
+Source page: [Disaster Rebuild Readiness](https://superagents-docs.vercel.app/recovery/disaster-rebuild)
+
+# Disaster Rebuild Readiness
+
+> **Current status: partially ready.** Super Agents documents the system, its owners, and the recovery order. The portal alone is not a complete backup and should not be treated as authorization to wipe every device.
+
+## What survives total device loss
+
+The system can be rebuilt only when the off-device sources named below remain accessible and independently recoverable.
+
+### GitHub repositories
+
+**Portal coverage:** Every accessible repository is enumerated in [Repository Coverage](/estate/repositories).
+
+**Before a total wipe:** Test a break-glass GitHub login and capture a dated manifest of required repositories and revisions.
+
+### Vault, Context, and Hermes
+
+**Portal coverage:** Ownership and recovery order are documented in the [System Registry](/reference/system-registry).
+
+**Before a total wipe:** Prove clean clones, unlock/setup checks, and restoration from a machine with no existing local state.
+
+### Credentials and MFA
+
+**Portal coverage:** Secrets belong in 1Password and source files retain references only.
+
+**Before a total wipe:** Test off-device 1Password recovery material, account recovery paths, and MFA backup methods without relying on a device that would be wiped.
+
+### Runtime configuration
+
+**Portal coverage:** Runtimes, versions, skills, plugins, agents, commands, profiles, MCPs, and jobs are inventoried.
+
+**Before a total wipe:** Capture machine setup as code for packages, runtime settings, launch services, app licenses, and non-secret configuration.
+
+### Schedulers and automations
+
+**Portal coverage:** Active and paused job counts and ownership are recorded.
+
+**Before a total wipe:** Restore exported definitions disabled, then enable each class only after delivery and evidence checks pass.
+
+### Cloud and application data
+
+**Portal coverage:** Google Drive, iCloud, GitHub, the vault, local state, and cold storage have declared roles.
+
+**Before a total wipe:** Maintain content-level backup inventories, retention expectations, and representative restore tests for each critical store.
+
+### Other devices and studio assets
+
+**Portal coverage:** The main, studio, and mobile machines are declared in [Devices & Hosts](/estate/devices).
+
+**Before a total wipe:** Directly attest the studio Mac and MacBook, including Ableton sessions, plugins, licenses, and the studio storage exception.
+
+### Deployed services
+
+**Portal coverage:** Delivery proof is linked from owning repositories.
+
+**Before a total wipe:** Maintain a service manifest covering projects, domains, databases, queues, webhooks, environment-variable references, and post-restore health checks.
+
+## Zero-device readiness gate
+
+Do not call the estate fully disaster-recoverable until all of these are true:
+
+1. A break-glass package exists off-device for 1Password, GitHub, primary email, Apple, Google, and deployment accounts, without storing plaintext credentials in this public repository.
+2. Active repositories and required revisions are captured in a dated machine-readable manifest.
+3. Host setup is reproducible from source-controlled package, runtime, service, scheduler, and configuration declarations.
+4. Every required secret has an owning 1Password item or reference and a documented consumer; no recovery step depends on local plaintext.
+5. Critical cloud, database, media, and studio data has a backup owner, retention target, and successful restore sample.
+6. Scheduler definitions can be restored disabled and re-enabled only after permissions, destinations, and evidence contracts are verified.
+7. A clean-host drill rebuilds one machine without borrowing hidden state from an existing device.
+8. The drill records elapsed time, failures, missing artifacts, and a GitHub closeout with the next remediation.
+
+## What “complete” means
+
+- **Documentation-complete** means the portal names every known class of component, owner, source, permission boundary, and recovery dependency at a sanitized level.
+- **Inventory-complete** means every accessible repository and every directly queried runtime surface is accounted for under the stated counting rules.
+- **Disaster-recovery complete** requires a successful clean-host restore from off-device sources. Documentation and inventory are necessary, but they are not proof of restoration.
+
+Until the clean-host gate passes, use this portal to coordinate recovery and expose gaps—not as the sole copy of operational state.
+
+---
+
+<!-- source-page: app/recovery/maintenance/page.mdx | route: https://superagents-docs.vercel.app/recovery/maintenance -->
+
+Source page: [Maintenance](https://superagents-docs.vercel.app/recovery/maintenance)
+
+# Maintenance
+
+## Weekly
+
+- Review failed or unverified fleet evidence.
+- Resolve runtime-to-vault inventory drift that affects active work.
+- Confirm critical repositories are pushed and deployments are healthy.
+
+## Monthly
+
+- Update runtime and plugin versions deliberately.
+- Audit paused, duplicate, or obsolete schedules.
+- Run dependency, secret, dead-link, and documentation freshness checks.
+- Test one representative recovery path.
+
+## Quarterly
+
+- Revalidate source-of-truth and storage assignments.
+- Review permission classes, connector access, and 1Password references.
+- Remove orphaned compatibility assets or document their intended owner.
+- Challenge the architecture with an independent bar-raiser review.
+
+Refresh the registry verification date only when the underlying checks were actually performed.
+
+---
+
+<!-- source-page: app/recovery/new-device/page.mdx | route: https://superagents-docs.vercel.app/recovery/new-device -->
+
+Source page: [New Device](https://superagents-docs.vercel.app/recovery/new-device)
+
+# New Device
+
+## Bootstrap sequence
+
+1. Install system prerequisites and the supported Node and Python versions.
+2. Configure GitHub access and the 1Password CLI without exporting plaintext credentials.
+3. Clone the private vault, Context, Hermes home, personal skills, and active project repositories to internal storage.
+4. Install Codex, Claude Code, Hermes, and deliberately adopted companion CLIs.
+5. Restore runtime configuration from Git-backed sources and reconnect managed plugins.
+6. Start shared local services only after checking their status.
+7. Run runtime version, gateway, MCP, repository, and messaging delivery checks.
+8. Restore schedules paused; enable them one class at a time after proof passes.
+
+The [system registry](/reference/system-registry) supplies per-system recovery expectations. Owning private runbooks contain machine-specific commands.
+
+---
+
+<!-- source-page: app/reference/page.mdx | route: https://superagents-docs.vercel.app/reference -->
+
+Source page: [Reference](https://superagents-docs.vercel.app/reference)
+
+# Reference
+
+- [System Registry](/reference/system-registry) — generated, dated operating contracts and snapshot facts
+- [Capability Inventory](/reference/capability-inventory) — generated, sanitized catalogs with explicit counting rules
+- [Canonical Sources](/reference/canonical-sources) — where to verify each subject
+- [Agent & Offline Export](/reference/agent-export) — download every page as one Markdown file or discover routes through `llms.txt` and the XML sitemap
+- [Glossary](/reference/glossary) — shared language for state, authority, and proof
+- [History & Scope](/reference/history) — why this portal replaced earlier documentation structures
+
+Reference pages help navigation. Live configuration remains with the owning system.
+
+---
+
+<!-- source-page: app/reference/agent-export/page.mdx | route: https://superagents-docs.vercel.app/reference/agent-export -->
+
+Source page: [Agent & Offline Export](https://superagents-docs.vercel.app/reference/agent-export)
+
+# Agent & Offline Export
+
+Use these generated, public artifacts to give an agent the complete sanitized documentation set or to save a portable copy on any device.
+
+## Download and discovery
+
+- [Download the complete Markdown corpus](/superagents.md) — every canonical documentation page in one file, with its source path and website route
+- [Open `llms.txt`](/llms.txt) — an agent-friendly discovery index linking the complete export, sitemap, repository, and every documentation page
+- [Open the XML sitemap](/sitemap.xml) — the canonical machine-readable route list
+- [Open the GitHub repository](https://github.com/GuillaumeRacine/superagents) — versioned sources and export generator
+
+The Markdown corpus and `llms.txt` are intentionally public because they contain only the same sanitized content already published in the public repository. Interactive website pages still require an approved Google account.
+
+## Agent usage
+
+Give an agent `https://superagents-docs.vercel.app/llms.txt` for discovery or `https://superagents-docs.vercel.app/superagents.md` when it needs the entire corpus in one request. On a phone or computer, open the Markdown link and use the browser's download or **Save to Files** action.
+
+## Freshness contract
+
+`npm run docs:generate` rebuilds both exports from every `app/**/page.mdx` file. CI compares the committed artifacts with the canonical pages and fails if a page is missing or either export is stale.
+
+---
+
+<!-- source-page: app/reference/canonical-sources/page.mdx | route: https://superagents-docs.vercel.app/reference/canonical-sources -->
+
+Source page: [Canonical Sources](https://superagents-docs.vercel.app/reference/canonical-sources)
+
+# Canonical Sources
+
+| Subject | Canonical source | This portal's role |
+|---|---|---|
+| Super Agents architecture and public snapshot | System registry in this repository | Render and explain |
+| Codex behavior | Applicable AGENTS.md chain and [official Codex customization docs](https://learn.chatgpt.com/docs/customization/overview) | Summarize the local operating model |
+| Codex project instructions | [Official AGENTS.md documentation](https://learn.chatgpt.com/docs/agent-configuration/agents-md) | Explain how the chain is used |
+| Codex subagents | [Official subagents documentation](https://learn.chatgpt.com/docs/agent-configuration/subagents) | Explain routing principles |
+| Codex scheduled tasks | [Official automations documentation](https://learn.chatgpt.com/docs/automations) | Explain ownership choices |
+| Next.js application behavior | [Official Next.js documentation](https://nextjs.org/docs) | Record the deployed version |
+| Claude configuration | Active runtime and private curated configuration tree | Describe reconciliation rules |
+| Hermes profiles and schedules | Private Hermes home and Context repositories | Publish sanitized contracts |
+| Automation health | Private Context inventory and fleet scoreboard | Explain evidence states |
+| Curated knowledge and storage policy | Private knowledge vault | Publish the model, not private content |
+| Deployed behavior | Production site or service | Link delivery proof from GitHub |
+
+Official product documentation establishes platform behavior. Local repositories establish Gui's configuration and policy. Live verification establishes what users can actually observe.
+
+---
+
+<!-- source-page: app/reference/capability-inventory/page.mdx | route: https://superagents-docs.vercel.app/reference/capability-inventory -->
+
+Source page: [Capability Inventory](https://superagents-docs.vercel.app/reference/capability-inventory)
+
+# Capability Inventory
+
+> Generated from `config/capability-inventory.json`. Do not edit this page directly.
+
+**Snapshot:** 2026-09-09T11:07:29-04:00
+
+**Scope:** Complete at the sanitized capability-group level. Private agent names, job names, personal schedules, and machine paths remain in their owning private inventories.
+
+This is the complete **sanitized** capability map. Exact private agent and job catalogs remain with their owning runtime because this source repository is public.
+
+| Inventory | Runtime | Count | Detail | State |
+|---|---|---|---|---|
+| [Codex personal skills](#codex-personal-skills) | Codex | 23 | item | active and resolvable |
+| [Codex managed plugin installs](#codex-managed-plugin-installs) | Codex | 22 | item | installed; capability activation is task-specific |
+| [Codex MCP services](#codex-mcp-services) | Codex | 7 | item | configured |
+| [Claude specialist agents](#claude-specialist-agents) | Claude Code | 111 | grouped-private | active private catalog |
+| [Claude slash commands](#claude-slash-commands) | Claude Code | 148 | grouped-private | active private catalog |
+| [Claude standalone skills](#claude-standalone-skills) | Claude Code | 26 | item | active |
+| [Claude plugins](#claude-plugins) | Claude Code | 13 | item | 13 registered; 12 enabled |
+| [Hermes profiles](#hermes-profiles) | Hermes | 6 | item | active |
+| [Hermes scheduled jobs](#hermes-scheduled-jobs) | Hermes | 82 | grouped-private | 61 enabled; 21 paused |
+| [Hermes active skills](#hermes-active-skills) | Hermes | 105 | grouped-private | active skill root |
+| [Companion and compatibility capabilities](#companion-and-compatibility-capabilities) | Gemini, Grok, OpenClaw, and OpenCode | 19 | grouped | companions installed; compatibility runtimes absent |
+
+## Codex personal skills
+
+**Runtime:** Codex
+
+**State:** active and resolvable
+
+**Published count:** 23
+
+**Detail level:** item
+
+**Source:** Active personal Codex skill root
+
+**Counting rule:** Direct child entries whose SKILL.md resolves to a readable file; managed system and plugin skills are excluded.
+
+| Capability or group | Purpose or state |
+|---|---|
+| adversarial-second-opinion-review | Strict second-pass review |
+| browser-fallback-artifacts | Recoverable browser fallback artifacts |
+| canary | Post-deployment monitoring |
+| check-resolvable | Routing and duplicate audit |
+| corporations-canada-annual-return | Federal annual-return operations |
+| design-shotgun | Parallel design exploration |
+| docs-audit | Documentation reconciliation |
+| ensembl3-workflows | Ensembl3 operations |
+| ensemble-studio | Shopify application studio |
+| guard | Maximum-safety execution mode |
+| ideal-state | System and project ideal-state analysis |
+| issue-sliced-implementation | Issue-to-slice implementation routing |
+| monarch-monthly-audit | Monthly finance-data audit |
+| no-ai-slop | Human writing edit pass |
+| office-hours | Adversarial product interrogation |
+| pdf | PDF reading, creation, and review |
+| plan-ceo-review | Founder-mode plan review |
+| quality-gate | Independent complex-work challenge |
+| quebec-corporate-annual-compliance | Quebec annual compliance |
+| shopify-visual-gift-enrichment | Evidence-backed commerce enrichment |
+| skillify | Workflow-to-skill conversion |
+| spec | Intent-to-executable-spec conversion |
+| video-use | Conversational video editing |
+
+## Codex managed plugin installs
+
+**Runtime:** Codex
+
+**State:** installed; capability activation is task-specific
+
+**Published count:** 22
+
+**Detail level:** item
+
+**Source:** Managed Codex plugin cache
+
+**Counting rule:** One current version directory per managed plugin across curated remote and bundled plugin roots.
+
+| Capability or group | Purpose or state |
+|---|---|
+| Canva | Design creation and review |
+| Browser | Managed browser automation runtime |
+| Chrome | Chrome integration |
+| Codex App Tools | Desktop application operations |
+| Computer Use | Computer interaction runtime |
+| Deep Research | Long-form sourced research |
+| Figma | Design and design-to-code workflows |
+| GitHub | Repository collaboration |
+| Gmail | Connected email workflows |
+| Google Calendar | Connected calendar workflows |
+| Google Contacts | Connected contact workflows |
+| Google Drive | Drive, Docs, Sheets, and Slides |
+| Hugging Face | Model, dataset, evaluation, and job workflows |
+| Lovable | Connected product-building workflows |
+| OpenAI Templates | Managed artifact templates |
+| Plugin Management | Plugin discovery and inspection |
+| Readwise | Connected reading workflows |
+| Sites | Website building and hosting |
+| Slack | Connected messaging workflows |
+| Unified Computer Use | Cross-surface computer interaction |
+| Visualize | Interactive visualizations |
+| Vercel | Application, AI, deployment, and platform workflows |
+
+## Codex MCP services
+
+**Runtime:** Codex
+
+**State:** configured
+
+**Published count:** 7
+
+**Detail level:** item
+
+**Source:** Active Codex configuration
+
+**Counting rule:** Distinct top-level MCP server sections in the active configuration.
+
+| Capability or group | Purpose or state |
+|---|---|
+| paper | Structured document and research artifacts |
+| terminal-commerce | Bounded commerce operations |
+| claude_design | Design collaboration |
+| node_repl | Persistent JavaScript execution |
+| computer-use | Authenticated browser and desktop interaction |
+| present-agent | Presentation and product operations |
+| firecrawl | Shared web search and extraction |
+
+## Claude specialist agents
+
+**Runtime:** Claude Code
+
+**State:** active private catalog
+
+**Published count:** 111
+
+**Detail level:** grouped-private
+
+**Source:** Active Claude agent catalog
+
+**Counting rule:** Top-level Markdown agent definitions; the generated AGENTS_INDEX.md navigation file is excluded.
+
+| Capability or group | Purpose or state |
+|---|---|
+| Research and academic | Scouting, extraction, synthesis, challenge, and orchestration |
+| Engineering and systems | Architecture, coding, QA, data validation, and runtime health |
+| Finance and risk | Treasury, tax, investment, audit, reconciliation, and risk roles |
+| Product and growth | Product management, experiments, marketing, community, and lead workflows |
+| Context and knowledge | Curation, linking, learning, indexing, and vault governance |
+| Media and publishing | Audio, visual, podcast, voice, recommendations, and release roles |
+| Personal operations | Calendar, contacts, tasks, travel, home, and communication roles |
+
+## Claude slash commands
+
+**Runtime:** Claude Code
+
+**State:** active private catalog
+
+**Published count:** 148
+
+**Detail level:** grouped-private
+
+**Source:** Active Claude command tree
+
+**Counting rule:** All Markdown command definitions recursively under the active command root.
+
+| Capability or group | Purpose or state |
+|---|---|
+| Delivery | Plan, build, test, review, deploy, and verify |
+| Research | Search, papers, monitoring, synthesis, and debate |
+| Operations | Status, audit, cleanup, sync, and recovery |
+| Knowledge | Context, memory, notes, vault, and learning |
+| Business | Finance, commerce, suppliers, growth, and portfolio work |
+| Publishing | Writing, visual review, media, slides, and distribution |
+| Personal | Tasks, reminders, travel, home, and weekly review |
+
+## Claude standalone skills
+
+**Runtime:** Claude Code
+
+**State:** active
+
+**Published count:** 26
+
+**Detail level:** item
+
+**Source:** Active Claude standalone skill root
+
+**Counting rule:** Direct child skill packages with a SKILL.md; manifests vendored inside dependencies are excluded.
+
+| Capability or group | Purpose or state |
+|---|---|
+| Figma | Design workflows |
+| Prompting | Prompt design |
+| annual-review | Annual synthesis |
+| call | Bounded calling workflow |
+| firecrawl | Core web research |
+| firecrawl-agent | Autonomous extraction |
+| firecrawl-build-interact | Dynamic-page integration |
+| firecrawl-build-onboarding | Credential and SDK setup |
+| firecrawl-build-scrape | Scrape integration |
+| firecrawl-build-search | Search integration |
+| firecrawl-crawl | Site crawling |
+| firecrawl-download | Website download |
+| firecrawl-interact | Live-page interaction |
+| firecrawl-map | URL discovery |
+| firecrawl-monitor | Change monitoring |
+| firecrawl-parse | Local file parsing |
+| firecrawl-research-index | Paper discovery |
+| firecrawl-scrape | Single-page extraction |
+| firecrawl-search | Web search |
+| github-projects | GitHub project operations |
+| monthly-review | Monthly synthesis |
+| morning-brief | Daily briefing |
+| no-ai-slop | Human writing edit pass |
+| quarterly-review | Quarterly synthesis |
+| video-use | Conversational video editing |
+| weekly-review | Weekly synthesis |
+
+## Claude plugins
+
+**Runtime:** Claude Code
+
+**State:** 13 registered; 12 enabled
+
+**Published count:** 13
+
+**Detail level:** item
+
+**Source:** Installed plugin registry and active Claude settings
+
+**Counting rule:** Distinct registered plugin keys; enabled state is read separately from active settings.
+
+| Capability or group | Purpose or state |
+|---|---|
+| ableton-live | Music production · enabled |
+| audio-analysis | Audio analysis · enabled |
+| compound-engineering | Engineering workflow · enabled |
+| dropbox-sync | Music asset synchronization · enabled |
+| figma | Design integration · enabled |
+| frontend-design | Frontend design · enabled |
+| lyrics | Lyric workflow · enabled |
+| ralph-loop | Iterative implementation · enabled |
+| rc600-import | Audio-device import · enabled |
+| release | Music release workflow · enabled |
+| shopify-ai-toolkit | Shopify application work · enabled |
+| swift-lsp | Swift language tooling · registered, not enabled |
+| tascam-import | Audio-device import · enabled |
+
+## Hermes profiles
+
+**Runtime:** Hermes
+
+**State:** active
+
+**Published count:** 6
+
+**Detail level:** item
+
+**Source:** Private Hermes profile root
+
+**Counting rule:** Direct profile directories in the active Hermes home.
+
+| Capability or group | Purpose or state |
+|---|---|
+| clinicfoundersassistant | Healthcare-business operations |
+| music | Music workflows |
+| ops | System and business operations |
+| personal | Personal operations |
+| research | Research workflows |
+| tao | Publishing and lead workflows |
+
+## Hermes scheduled jobs
+
+**Runtime:** Hermes
+
+**State:** 61 enabled; 21 paused
+
+**Published count:** 82
+
+**Detail level:** grouped-private
+
+**Source:** Private Hermes cron registry
+
+**Counting rule:** Every job object in the active jobs registry; enabled and paused are partitioned by the enabled Boolean.
+
+| Capability or group | Purpose or state |
+|---|---|
+| System health and telemetry | Runtime health, quota, metrics, cleanup, and watchdog work |
+| Research and intelligence | Primary-source monitoring, briefs, market scans, and synthesis |
+| Business and portfolio | Company reviews, growth loops, operations, and reporting |
+| Finance and records | Treasury, close, freshness, P&L, and compliance-oriented work |
+| Inbox and messaging | Triage, drafts, delivery, curation, and notification work |
+| Personal and media | Personal reviews, notes, voice, and media workflows |
+
+## Hermes active skills
+
+**Runtime:** Hermes
+
+**State:** active skill root
+
+**Published count:** 105
+
+**Detail level:** grouped-private
+
+**Source:** Active Hermes skill root
+
+**Counting rule:** SKILL.md files recursively under the active user skill root; runtime source, optional packs, and vendored dependencies are excluded.
+
+| Capability or group | Purpose or state |
+|---|---|
+| Apple | 5 skills |
+| Autonomous agent runtimes | 4 skills |
+| Creative | 16 skills |
+| Data science | 1 skill |
+| DevOps | 4 skills |
+| Email | 3 skills |
+| GitHub | 6 skills |
+| Investing | 1 skill |
+| Media | 4 skills |
+| MLOps | 7 skills |
+| Note taking | 2 skills |
+| Productivity and operations | 29 skills |
+| Research | 7 skills |
+| Smart home | 1 skill |
+| Social media | 1 skill |
+| Software development | 10 skills |
+| Uncategorized top-level | 4 skills |
+
+## Companion and compatibility capabilities
+
+**Runtime:** Gemini, Grok, OpenClaw, and OpenCode
+
+**State:** companions installed; compatibility runtimes absent
+
+**Published count:** 19
+
+**Detail level:** grouped
+
+**Source:** Active companion configuration and compatibility roots
+
+**Counting rule:** Configured MCP and command entries for installed companions, plus skill manifests in the inactive OpenClaw compatibility root.
+
+| Capability or group | Purpose or state |
+|---|---|
+| Gemini CLI | One shared Firecrawl MCP; no local skill manifests |
+| Grok CLI | Two custom commands and one shared Firecrawl MCP |
+| OpenClaw compatibility | 15 skill manifests; runtime absent |
+| OpenCode compatibility | Configuration assets; runtime absent |
+
+---
+
+<!-- source-page: app/reference/glossary/page.mdx | route: https://superagents-docs.vercel.app/reference/glossary -->
+
+Source page: [Glossary](https://superagents-docs.vercel.app/reference/glossary)
+
+# Glossary
+
+**Active** — configured and currently part of an operating path.
+
+**Approval class** — the authorization required before an action may run.
+
+**Canonical source** — the designated owner of a type of information.
+
+**Compatibility-only** — assets exist for portability, but no target runtime is active.
+
+**Context** — information supplied to the current run.
+
+**Derived index** — a navigation or reporting view whose facts come from owning sources.
+
+**Evidence contract** — the independent signal required to verify a claimed outcome.
+
+**Installed** — code or configuration exists; use is not implied.
+
+**Memory** — information retained or retrieved across runs.
+
+**MCP service** — a structured capability exposed to a model runtime through Model Context Protocol.
+
+**Paused** — deliberately disabled while its definition remains.
+
+**Skill** — a reusable workflow package with instructions and optional references, scripts, or assets.
+
+**Verified** — independent evidence supports the claimed result.
+
+---
+
+<!-- source-page: app/reference/history/page.mdx | route: https://superagents-docs.vercel.app/reference/history -->
+
+Source page: [History & Scope](https://superagents-docs.vercel.app/reference/history)
+
+# History & Scope
+
+This repository is the canonical website for Gui's sanitized system map.
+
+The 2026 refresh replaced a 112-page generated site that concentrated on one Claude configuration snapshot. That structure duplicated volatile counts, mixed runtime and curated-vault state, and preserved outdated storage, scheduling, and recovery assumptions.
+
+Two related repositories have narrower roles:
+
+- **super_agents** is a separate sanitized reusable template. **Super Agents** and the `superagents` repository are the source-of-truth documentation umbrella for the personal runtime fleet.
+- **documentation** is a legacy process collection and historical input, not the current portal.
+
+## Publication boundary
+
+This repository is public. The deployed website has an additional access gate, but confidentiality cannot depend on it. Only sanitized architecture, workflow, and operating metadata belong in the current tree.
+
+Private runbooks, machine paths, credentials, personal context, customer data, and private service URLs remain with their owning systems.
+
+The portal was previously named InnerOS. It was renamed **Super Agents** when its scope expanded to the complete agentic estate across runtimes, tools, skills, workflows, repositories, data sources, and devices.
+
+Legacy commits predate the current publication controls and may contain historical machine paths or operational metadata. Treat repository history as untrusted until the tracked privacy-hardening work in [GitHub issue #4](https://github.com/GuillaumeRacine/superagents/issues/4) is complete; the current-tree publication scan does not claim to sanitize prior commits.
+
+---
+
+<!-- source-page: app/reference/system-registry/page.mdx | route: https://superagents-docs.vercel.app/reference/system-registry -->
+
+Source page: [System Registry](https://superagents-docs.vercel.app/reference/system-registry)
+
+# System Registry
+
+> Generated from `config/system-registry.json`. Do not edit this page directly.
+
+**Snapshot:** 2026-09-09T11:07:29-04:00
+
+**Scope:** Sanitized architecture and operating metadata only; no credentials, personal context, private URLs, or customer data.
+
+This registry is a **derived index**, not a replacement for each runtime's source of truth. A scheduler reporting success is not independent proof that its outcome was correct.
+
+| System | Kind | Status | Last verified |
+|---|---|---|---|
+| [Codex](/runtimes/codex) | interactive agent runtime | active · primary project-delivery surface | 2026-09-08 |
+| [Claude Code](/runtimes/claude-code) | interactive agent runtime | active · specialist catalog and plugin surface | 2026-09-08 |
+| [Hermes](/runtimes/hermes) | persistent agent gateway and scheduler | active · messaging and unattended operations | 2026-09-08 |
+| [Context control plane](/context-memory) | automation, evidence, and fleet inventory | active · authoritative automation registry | 2026-09-08 |
+| [Knowledge vault](/context-memory/storage) | curated context and durable knowledge | active · private Git-backed knowledge source | 2026-09-08 |
+| [Shared Firecrawl MCP broker](/capabilities/mcp-tools) | shared web research service | active · shared local service | 2026-09-08 |
+| [Gemini CLI](/runtimes/companions) | companion interactive runtime | installed · bounded companion surface | 2026-09-08 |
+| [Grok CLI](/runtimes/companions) | companion interactive runtime | installed · bounded companion surface | 2026-09-08 |
+| [Compatibility assets](/runtimes/companions) | inactive interoperability files | compatibility-only · no active OpenClaw or OpenCode binary | 2026-09-08 |
+| [Super Agents documentation portal](/reference/canonical-sources) | derived documentation and navigation | active · sanitized derived index | 2026-09-09 |
+
+## Codex
+
+**Status:** active · primary project-delivery surface
+
+**Version:** 0.147.0
+
+**Owner:** Gui
+
+**Last verified:** 2026-09-08
+
+| Contract | Value |
+|---|---|
+| Source of truth | Global and repository AGENTS.md files, Git-backed personal skills, and installed plugin manifests |
+| Measurement | Live CLI version; resolvable direct skill manifests; one current directory per managed plugin; distinct MCP sections; desktop automation definitions and statuses. |
+| Trigger | Interactive desktop, CLI, or IDE task; optional desktop scheduled task |
+| Permissions | Per-task filesystem, network, app, and approval policy; connectors retain their own authorization |
+| Inputs | Prompt, AGENTS.md chain, repository, thread history, memories, selected skills and plugins |
+| Outputs | Workspace changes, reviews, artifacts, GitHub commits, deployments, and verification evidence |
+| Proof | Targeted checks, full build when required, commit, deploy reference, live checks, and tracking issue comment |
+| Recovery | Install Codex, restore Git repositories and AGENTS.md, restore Git-backed skills, then reconnect plugins and MCP services |
+| Snapshot counts | Usable Top Level Personal Skills: 23; Unresolved Top Level Skill Entries: 55; Managed Plugin Installs: 22; Configured Mcp Servers: 7; Desktop Automations: 2; Active Desktop Automations: 0 |
+
+## Claude Code
+
+**Status:** active · specialist catalog and plugin surface
+
+**Version:** 2.1.266
+
+**Owner:** Gui
+
+**Last verified:** 2026-09-08
+
+| Contract | Value |
+|---|---|
+| Source of truth | Active Claude runtime reconciled with the private vault's Claude configuration tree |
+| Measurement | Live CLI version; direct agent Markdown excluding the generated index; recursive command Markdown; direct skill manifests excluding vendored dependencies; plugin registry and active settings. |
+| Trigger | Interactive CLI or editor session; project instructions and plugins may add behavior |
+| Permissions | Claude settings, hooks, project policy, and each connected service's authorization |
+| Inputs | Prompt, CLAUDE.md chain, project files, agents, commands, skills, plugins, and session memory |
+| Outputs | Workspace changes, analysis, artifacts, and delegated agent results |
+| Proof | Repository checks plus the same GitHub/deploy closeout contract used by other coding runtimes |
+| Recovery | Restore the private vault and runtime settings, run the guarded setup workflow, then compare runtime and vault inventories before use |
+| Snapshot counts | Agent Definitions: 111; Slash Commands: 148; Standalone Skill Manifests: 26; Registered Plugins: 13; Enabled Plugins: 12; Path Rules: 5; Hook Files: 3 |
+
+## Hermes
+
+**Status:** active · messaging and unattended operations
+
+**Version:** 0.17.0 · local fork with 39 carried commits
+
+**Owner:** Gui
+
+**Last verified:** 2026-09-08
+
+| Contract | Value |
+|---|---|
+| Source of truth | Private Hermes home repository for personalization and schedules; public Hermes fork for runtime code |
+| Measurement | Live CLI version; direct profile directories; active cron registry job objects partitioned by enabled state; recursive manifests under the active user skill root only. |
+| Trigger | Message, gateway request, cron schedule, or local operational event |
+| Permissions | Profile toolsets, action class, approval class, connector authorization, and scheduler policy |
+| Inputs | Soul, selected profile, memories, skills, message context, repository context, and tool results |
+| Outputs | Slack, Telegram, or Discord replies; local artifacts; monitored workflow results |
+| Proof | Scheduler output plus independent evidence contracts and the Context fleet scoreboard |
+| Recovery | Restore the private Hermes home repository and secrets from 1Password, install the public runtime fork, restore launch services, then run gateway and delivery checks |
+| Snapshot counts | Profiles: 6; Scheduled Jobs: 82; Enabled Jobs: 61; Paused Jobs: 21; Active User Skill Manifests: 105 |
+
+## Context control plane
+
+**Status:** active · authoritative automation registry
+
+**Version:** repository revision 07b3fc0 baseline plus live working-state inventory
+
+**Owner:** Gui
+
+**Last verified:** 2026-09-08
+
+| Contract | Value |
+|---|---|
+| Source of truth | Private Context repository manifests, scripts, evidence contracts, and generated fleet scoreboard |
+| Measurement | Generated system inventory reconciled with live runtime state and the fleet scoreboard snapshot. |
+| Trigger | Hermes cron, GitHub Actions, launch services, or an explicit operator run |
+| Permissions | Declared action and approval class per system; external writes require a preapproved playbook or operator approval |
+| Inputs | Scheduler definitions, local runtime status, collector outputs, evidence contracts, and repository state |
+| Outputs | System inventory, fleet scoreboard, proof artifacts, alerts, and curated context updates |
+| Proof | Generated inventory and scoreboard with explicit verified, unverified, failed, idle, and paused states |
+| Recovery | Clone the private Context repository, restore referenced credentials, validate scheduled surfaces, then regenerate the inventory and scoreboard |
+| Snapshot counts | Declared Core Systems: 13; Active Core Systems: 12; Paused Core Systems: 1 |
+
+## Knowledge vault
+
+**Status:** active · private Git-backed knowledge source
+
+**Version:** Git-backed current vault
+
+**Owner:** Gui
+
+**Last verified:** 2026-09-08
+
+| Contract | Value |
+|---|---|
+| Source of truth | Private vault repository; canonical storage policy lives in its InnerContext area |
+| Measurement | Repository status and current canonical storage policy reviewed at the snapshot date; no volatile count published. |
+| Trigger | Human curation, approved automation update, or explicit agent workflow |
+| Permissions | Private repository access; sensitive areas remain encrypted; secrets are prohibited |
+| Inputs | Curated decisions, goals, identity context, workflows, research syntheses, and system guidance |
+| Outputs | Versioned knowledge and context consumed selectively by agent runtimes |
+| Proof | Git history, link checks, storage-policy compliance, and reviewable automation diffs |
+| Recovery | Clone the private repository, unlock approved encrypted content, run its setup checks, and reconnect runtime references |
+| Snapshot counts | No volatile count published |
+
+## Shared Firecrawl MCP broker
+
+**Status:** active · shared local service
+
+**Version:** shared endpoint contract
+
+**Owner:** Gui
+
+**Last verified:** 2026-09-08
+
+| Contract | Value |
+|---|---|
+| Source of truth | Local broker launcher and the shared Firecrawl CLI configuration |
+| Measurement | Broker status command plus a bounded local endpoint health check. |
+| Trigger | A configured agent runtime requests web search, scrape, crawl, or extraction |
+| Permissions | Local MCP endpoint; service credentials resolve once per authorized 1Password session |
+| Inputs | Public URLs, search queries, and structured extraction requests |
+| Outputs | Search results, page content, crawl maps, and extraction artifacts |
+| Proof | Broker health check plus a bounded read-only request from the calling runtime |
+| Recovery | Restore the launcher, resolve the 1Password reference once, start the broker only if stopped, then test the local health endpoint |
+| Snapshot counts | Local Endpoints: 1 |
+
+## Gemini CLI
+
+**Status:** installed · bounded companion surface
+
+**Version:** 0.34.0
+
+**Owner:** Gui
+
+**Last verified:** 2026-09-08
+
+| Contract | Value |
+|---|---|
+| Source of truth | Local Gemini configuration plus Git-backed project instructions |
+| Measurement | Live CLI version, configured MCP entries, and local skill manifest count. |
+| Trigger | Explicit interactive CLI use |
+| Permissions | Local CLI policy and connector authorization |
+| Inputs | Prompt, repository context, Gemini instructions, and configured MCP results |
+| Outputs | Analysis and workspace changes when explicitly requested |
+| Proof | Repository-specific verification and GitHub closeout contract |
+| Recovery | Install the CLI, restore non-secret configuration, authenticate, and validate the shared MCP connection |
+| Snapshot counts | Configured Mcp Servers: 1; Local Skill Manifests: 0 |
+
+## Grok CLI
+
+**Status:** installed · bounded companion surface
+
+**Version:** 1.0.5
+
+**Owner:** Gui
+
+**Last verified:** 2026-09-08
+
+| Contract | Value |
+|---|---|
+| Source of truth | Local Grok configuration and marketplace-managed runtime files |
+| Measurement | Live CLI version, configured MCP entries, and direct custom-command inventory. |
+| Trigger | Explicit interactive CLI use |
+| Permissions | Local CLI policy, marketplace configuration, and connector authorization |
+| Inputs | Prompt, repository context, commands, and configured MCP results |
+| Outputs | Analysis and workspace changes when explicitly requested |
+| Proof | Repository-specific verification and GitHub closeout contract |
+| Recovery | Install the stable CLI, restore non-secret configuration, authenticate, and validate the shared MCP connection |
+| Snapshot counts | Custom Commands: 2; Configured Mcp Servers: 1 |
+
+## Compatibility assets
+
+**Status:** compatibility-only · no active OpenClaw or OpenCode binary
+
+**Version:** not applicable
+
+**Owner:** Gui
+
+**Last verified:** 2026-09-08
+
+| Contract | Value |
+|---|---|
+| Source of truth | Local compatibility skill directories |
+| Measurement | Executable lookup for target runtimes plus recursive manifest count in the compatibility root. |
+| Trigger | Explicit migration or interoperability work only |
+| Permissions | No runtime authority while the corresponding binary is absent |
+| Inputs | Existing skill definitions and migration requirements |
+| Outputs | Portability analysis or converted skill packages |
+| Proof | Install-state check and target-runtime validation |
+| Recovery | Install a target runtime only when deliberately adopted; otherwise retain the assets as inactive references |
+| Snapshot counts | Open Claw Compatibility Skills: 15; Active Runtimes: 0 |
+
+## Super Agents documentation portal
+
+**Status:** active · sanitized derived index
+
+**Version:** Next.js 16.3.4 · Nextra 4.6.1
+
+**Owner:** Gui
+
+**Last verified:** 2026-09-09
+
+| Contract | Value |
+|---|---|
+| Source of truth | This GitHub repository; runtime truth remains with each owning system |
+| Measurement | Pinned package lock, generated registry checks, production build, access matrix, search index, responsive browser review, and deployment evidence. |
+| Trigger | Reviewed documentation change merged to the deploy branch |
+| Permissions | Public source content must remain sanitized; rendered routes require a Google-verified session whose email exactly matches one of the server-side allowlist entries; domain-wide access is rejected |
+| Inputs | Reviewed registry snapshot, authoritative runbooks, official product docs, and bar-raiser findings |
+| Outputs | Searchable Nextra site, source map, operating guides, and dated system snapshot |
+| Proof | CI checks, dependency audit, production deployment, anonymous redirect and OAuth-provider checks, allowlist rejection, authenticated route checks, and issue closeout |
+| Recovery | Clone the repository, use the pinned Node version, regenerate the registry page, run checks and build, restore the Google OAuth client and exact-address allowlist from managed secrets, then redeploy |
+| Snapshot counts | No volatile count published |
+
+---
+
+<!-- source-page: app/runtimes/page.mdx | route: https://superagents-docs.vercel.app/runtimes -->
+
+Source page: [Systems & Surfaces](https://superagents-docs.vercel.app/runtimes)
+
+# Systems & Surfaces
+
+The runtime fleet is intentionally heterogeneous. Each system has a job; none is the universal source of truth.
+
+| Runtime | State | Best at |
+|---|---|---|
+| Codex | Active | Repository delivery, review, deployment, app-integrated workflows |
+| Claude Code | Active | Specialist catalogs, commands, plugins, interactive project work |
+| Hermes | Active | Persistent gateway, messaging, schedules, unattended operations |
+| Gemini CLI | Installed | Explicit companion analysis or implementation |
+| Grok CLI | Installed | Explicit companion analysis or implementation |
+| OpenClaw / OpenCode | Compatibility-only | Migration assets; no active runtime at snapshot |
+
+See [the registry](/reference/system-registry) for dated versions and counts.
+
+---
+
+<!-- source-page: app/runtimes/claude-code/page.mdx | route: https://superagents-docs.vercel.app/runtimes/claude-code -->
+
+Source page: [Claude Code](https://superagents-docs.vercel.app/runtimes/claude-code)
+
+# Claude Code
+
+Claude Code is an active interactive runtime with the largest local catalog of specialist agents, slash commands, standalone skills, plugins, rules, and hooks.
+
+## Context chain
+
+The runtime reads its prompt and session, the applicable `CLAUDE.md` chain, project files, selected agents or commands, enabled plugins, and configured memory. Hooks and path rules can refine behavior.
+
+## Important distinction
+
+The active runtime tree and the vault's curated Claude tree are related but not identical. They are regular directories with divergent inventories, not live mirrors. Treat differences as a reconciliation task, never as proof that one silently updated the other.
+
+## Delivery contract
+
+For repository work, Claude follows the same durable endpoint as Codex: relevant checks, commit, push, deployment when applicable, live verification, and a GitHub evidence record.
+
+---
+
+<!-- source-page: app/runtimes/codex/page.mdx | route: https://superagents-docs.vercel.app/runtimes/codex -->
+
+Source page: [Codex](https://superagents-docs.vercel.app/runtimes/codex)
+
+# Codex
+
+Codex is the primary project-delivery surface: inspect, implement, test, commit, push, deploy, verify, and record proof.
+
+## Context chain
+
+Codex combines the current prompt and thread with global and repository `AGENTS.md` instructions, workspace files, selected skills or plugins, memories, and connected tools. More specific repository instructions refine global policy.
+
+## Capabilities
+
+- Interactive desktop, CLI, and IDE work
+- Bounded subagents for independent subtasks
+- Personal skills and managed plugin skills
+- MCP services, browser, computer use, artifacts, and GitHub workflows
+- Desktop scheduled tasks for lightweight follow-up work
+
+## Operating boundary
+
+Tool availability is not blanket permission. Filesystem, network, app, connector, and approval policies still apply per task. Codex owns delivery execution; authoritative product state remains in the repository and live deployment.
+
+Current official concepts and runtime-specific details are linked from [Canonical Sources](/reference/canonical-sources).
+
+The current [system registry](/reference/system-registry) records unresolved top-level skill entries alongside the usable count. Visible filesystem entries are not considered capabilities unless their manifest resolves successfully.
+
+---
+
+<!-- source-page: app/runtimes/companions/page.mdx | route: https://superagents-docs.vercel.app/runtimes/companions -->
+
+Source page: [Companions & Compatibility](https://superagents-docs.vercel.app/runtimes/companions)
+
+# Companions & Compatibility
+
+Gemini CLI and Grok CLI are installed companion runtimes for explicit use. They inherit the repository's delivery and proof expectations; being installed does not make either an unattended operator.
+
+Both can reach the shared Firecrawl service through local configuration. Gemini had no local skill manifests at the registry snapshot. Grok had a small custom-command surface.
+
+## Compatibility-only assets
+
+OpenClaw-compatible skills and OpenCode-related files exist for portability, but neither target binary was active at the snapshot. These assets have no runtime authority until the corresponding system is deliberately installed, configured, and verified.
+
+Use the [registry](/reference/system-registry) for dated versions and counts.
+
+---
+
+<!-- source-page: app/runtimes/hermes/page.mdx | route: https://superagents-docs.vercel.app/runtimes/hermes -->
+
+Source page: [Hermes](https://superagents-docs.vercel.app/runtimes/hermes)
+
+# Hermes
+
+Hermes is the persistent agent gateway and primary scheduler. It connects profiles, memory, skills, messaging adapters, cron jobs, and local operational services.
+
+## What it owns
+
+- Six task-oriented profiles at the current snapshot
+- Slack, Telegram, and Discord delivery paths
+- The main unattended job catalog
+- Persistent memory and profile-specific toolsets
+- Scheduled entry points into Context automation
+
+## Authority model
+
+A job needs both a schedule and a permission contract. Read-only collection can run unattended. Notifications, external mutations, financial actions, and irreversible changes require an explicit preapproved playbook or operator approval.
+
+## Proof model
+
+Scheduler state proves that a job was invoked. Outcome evidence belongs in the Context fleet scoreboard or the system's own durable destination. See [Fleet Evidence](/automation/fleet-evidence).
+
+---
+
+<!-- source-page: app/start-here/page.mdx | route: https://superagents-docs.vercel.app/start-here -->
+
+Source page: [Start Here](https://superagents-docs.vercel.app/start-here)
+
+# Start Here
+
+Use this section to orient yourself before changing the system.
+
+## What Super Agents is
+
+Super Agents is the complete multi-runtime operating model for project delivery, research, personal operations, publishing, and unattended work. Interactive agents do focused work. Hermes handles persistent messaging and schedules. Context records automation and fleet evidence. The vault holds curated knowledge. GitHub and deployed surfaces provide the durable delivery record.
+
+## What this site is
+
+This portal is a sanitized, derived map designed for fast navigation. It deliberately excludes credentials, private URLs, personal records, customer data, and instructions that would grant authority on their own.
+
+It is not a live control plane. Use the [system registry](/reference/system-registry) to find the owning source and verification date for a surface.
+
+## First three reads
+
+1. [Choose a runtime](/start-here/choose-a-runtime) for the work at hand.
+2. Follow the [operating loop](/start-here/operating-loop) for material changes.
+3. Check [permissions](/governance/permissions) before an external write, notification, purchase, or irreversible action.
+
+## Status language
+
+- **Active** — configured and currently part of an operating path.
+- **Installed** — available, but not necessarily used or scheduled.
+- **Paused** — deliberately disabled while definitions remain.
+- **Compatibility-only** — assets exist, but no target runtime is active.
+- **Verified** — an independent check supports the claimed outcome.
+
+---
+
+<!-- source-page: app/start-here/choose-a-runtime/page.mdx | route: https://superagents-docs.vercel.app/start-here/choose-a-runtime -->
+
+Source page: [Choose a Runtime](https://superagents-docs.vercel.app/start-here/choose-a-runtime)
+
+# Choose a Runtime
+
+Choose the smallest surface that already owns the context and permissions the task needs.
+
+| Need | Default | Why |
+|---|---|---|
+| Repository change, test, review, deploy, or live verification | **Codex** | It is the primary project-delivery surface and integrates workspace, GitHub, browser, and review workflows. |
+| Existing specialist agent, slash command, or Claude plugin | **Claude Code** | It owns the large specialist catalog and Claude-specific configuration. |
+| Scheduled work, messaging gateway, or unattended follow-up | **Hermes** | It owns persistent profiles, delivery adapters, and the main job scheduler. |
+| A second model perspective | **Gemini CLI or Grok CLI** | Use explicitly and keep the same repository proof contract. |
+| Fleet evidence, automation definitions, or health state | **Context** | It owns the system inventory and evidence contracts. |
+
+## Delegate only bounded work
+
+Use a subagent when a concrete subtask can run independently: a targeted review, research slice, or isolated implementation. Keep the parent responsible for integration, safety decisions, and closeout proof.
+
+Avoid parallel agents editing the same files or controlling the same browser profile. For high-risk changes, separate implementation from independent review.
+
+## Compatibility is not adoption
+
+OpenClaw and OpenCode compatibility files exist, but their runtimes were not installed at the registry snapshot. Do not route production work to them until deliberately adopted and verified.
+
+---
+
+<!-- source-page: app/start-here/operating-loop/page.mdx | route: https://superagents-docs.vercel.app/start-here/operating-loop -->
+
+Source page: [Operating Loop](https://superagents-docs.vercel.app/start-here/operating-loop)
+
+# Operating Loop
+
+Material work follows one observable loop.
+
+```text
+Intent → inspect owner → plan authority → change → targeted checks
+       → full build when needed → commit → push → deploy
+       → live verification → GitHub evidence → next action
+```
+
+## Before work
+
+1. Identify the owning repository or runtime.
+2. Read its local instruction chain.
+3. Inspect current state and preserve unrelated work.
+4. Classify the action: read-only, local write, notification, external mutation, money, or irreversible.
+
+## During work
+
+- Run focused checks after small iterations.
+- Run a full build for runtime, route, packaging, or deployment changes.
+- Prefer staging, dry runs, or plan-only proof for risky behavior.
+- Keep external writes separate from deployment verification.
+
+## Closeout
+
+Commit and push the coherent slice. Let the intended deployment run, verify the real surface, then record the commit, deploy reference, exact checks, pass/fail outcome, and residual risk in GitHub.
+
+Local files are working state, not the durable endpoint for material work.
+
+---
+
+<!-- source-page: app/workflows/page.mdx | route: https://superagents-docs.vercel.app/workflows -->
+
+Source page: [Workflows](https://superagents-docs.vercel.app/workflows)
+
+# Workflows
+
+Workflows connect runtimes, capabilities, context, permission classes, and proof around an outcome.
+
+| Workflow | Typical path |
+|---|---|
+| Project delivery | Codex or Claude → repository checks → GitHub → deployment → live proof |
+| Research | Search and primary sources → synthesis → citations → curated destination |
+| Personal operations | Hermes schedule or message → Context contract → evidence → alert when actionable |
+| Publishing | Brief → research → drafting → review → fact check → approval → channel-specific release |
+
+Each workflow page documents the invariant contract rather than duplicating a volatile agent catalog.
+
+---
+
+<!-- source-page: app/workflows/personal-operations/page.mdx | route: https://superagents-docs.vercel.app/workflows/personal-operations -->
+
+Source page: [Personal Operations](https://superagents-docs.vercel.app/workflows/personal-operations)
+
+# Personal Operations
+
+Hermes and Context coordinate recurring personal operations.
+
+## Pattern
+
+```text
+Schedule or message → profile → bounded tools → durable destination
+                    → independent evidence → notify only if actionable
+```
+
+Collectors should default to read-only. A workflow that messages someone, changes a service, spends money, or performs an irreversible action needs a declared approval class.
+
+Curated outcomes can update the private knowledge vault through a reviewable workflow. Raw credentials and noisy transient state never belong there.
+
+Use [Scheduling](/automation/scheduling) to choose the execution surface and [Fleet Evidence](/automation/fleet-evidence) to interpret the result.
+
+---
+
+<!-- source-page: app/workflows/project-delivery/page.mdx | route: https://superagents-docs.vercel.app/workflows/project-delivery -->
+
+Source page: [Project Delivery](https://superagents-docs.vercel.app/workflows/project-delivery)
+
+# Project Delivery
+
+Use Codex by default for a coherent repository change; use Claude Code when its specialist catalog or project context is the better fit.
+
+## Delivery path
+
+1. Find the active internal-storage repository and its GitHub remote.
+2. Read global and repository instructions.
+3. Inspect working state; preserve unrelated edits.
+4. Implement the smallest coherent slice.
+5. Run targeted checks continuously and a full build when runtime or deploy behavior changed.
+6. Commit and push to GitHub.
+7. Verify deployment and live behavior.
+8. Record commit, deploy, checks, outcome, and residual risk in the tracking issue or pull request.
+
+For risky behavior, use staging and feature flags where the project provides them.
+
+---
+
+<!-- source-page: app/workflows/publishing/page.mdx | route: https://superagents-docs.vercel.app/workflows/publishing -->
+
+Source page: [Publishing](https://superagents-docs.vercel.app/workflows/publishing)
+
+# Publishing
+
+Publishing is a staged workflow, not one universal agent pipeline.
+
+## Invariant stages
+
+1. Define audience, purpose, channel, and approval owner.
+2. Research from current primary sources.
+3. Build the narrative and outline.
+4. Draft in the target voice.
+5. Challenge structure and claims independently.
+6. Fact-check and attach citations.
+7. Adapt to each distribution surface.
+8. Obtain required approval, publish, and verify the live result.
+9. Store the canonical asset and update the content index.
+
+Specialist agents may implement individual stages. Their exact names and counts are runtime inventory, not the workflow itself.
+
+---
+
+<!-- source-page: app/workflows/research/page.mdx | route: https://superagents-docs.vercel.app/workflows/research -->
+
+Source page: [Research](https://superagents-docs.vercel.app/workflows/research)
+
+# Research
+
+## Research path
+
+1. Frame the decision and freshness requirement.
+2. Prefer official documentation, primary sources, or the owning dataset.
+3. Use the shared research service for broad discovery and structured extraction.
+4. Distinguish sourced facts, live observations, and inference.
+5. Cite the supporting page close to each material claim.
+6. Save the synthesis in the owning repository or curated knowledge destination.
+
+Do not copy entire web sources into the vault or portal. Preserve durable conclusions, provenance, checked dates, and decision impact.
+
+For platform decisions, refresh current official documentation before implementation.

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -18,7 +18,7 @@ function walk(directory) {
 
 const files = walk(root).filter((file) => textExtensions.has(extname(file)))
 const publishable = files.filter((file) => !['package-lock.json', 'scripts/check-docs.mjs'].includes(relative(root, file)))
-const historicalBrandAllowlist = new Set(['AGENTS.md', 'app/reference/history/page.mdx'])
+const historicalBrandAllowlist = new Set(['AGENTS.md', 'app/reference/history/page.mdx', 'public/superagents.md'])
 
 const forbiddenPublicationPatterns = [
   [/\/Users\/[A-Za-z0-9._-]+\//g, 'absolute home path'],
@@ -47,6 +47,14 @@ const routeFiles = new Set(appPages.map((file) => {
   const name = relative(resolve(root, 'app'), file).replace(/\/page\.mdx$/, '')
   return name ? `/${name}` : '/'
 }))
+const staticRoutes = new Set([
+  '/llms.txt',
+  '/robots.txt',
+  '/sitemap.xml',
+  ...files
+    .filter((file) => file.startsWith(resolve(root, 'public')))
+    .map((file) => `/${relative(resolve(root, 'public'), file)}`),
+])
 
 const requiredLegacyRoutes = [
   '/getting-started',
@@ -78,7 +86,7 @@ for (const file of appPages) {
 
   for (const match of content.matchAll(/\[[^\]]+\]\((\/[^)\s#?]*)(?:[?#][^)]*)?\)/g)) {
     const target = match[1] || '/'
-    if (!routeFiles.has(target)) failures.push(`${relative(root, file)} links to missing route ${target}`)
+    if (!routeFiles.has(target) && !staticRoutes.has(target)) failures.push(`${relative(root, file)} links to missing route ${target}`)
   }
 }
 

--- a/scripts/generate-agent-exports.mjs
+++ b/scripts/generate-agent-exports.mjs
@@ -1,0 +1,107 @@
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import registry from '../config/system-registry.json' with { type: 'json' }
+
+const root = process.cwd()
+const appRoot = resolve(root, 'app')
+const publicRoot = resolve(root, 'public')
+const siteUrl = 'https://superagents-docs.vercel.app'
+const checkOnly = process.argv.includes('--check')
+
+function pageFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(directory, entry.name)
+    if (entry.isDirectory()) return pageFiles(fullPath)
+    return entry.name === 'page.mdx' ? [fullPath] : []
+  })
+}
+
+function routeFor(file) {
+  const routeDirectory = relative(appRoot, dirname(file))
+  return routeDirectory ? `/${routeDirectory}` : '/'
+}
+
+function titleFor(content, route) {
+  return content.match(/^#\s+(.+)$/m)?.[1]?.replace(/[*_`]/g, '') ?? route
+}
+
+const pages = pageFiles(appRoot)
+  .map((file) => {
+    const content = readFileSync(file, 'utf8').trim()
+    const route = routeFor(file)
+    return {
+      content,
+      file: relative(root, file),
+      route,
+      title: titleFor(content, route),
+      url: `${siteUrl}${route === '/' ? '' : route}`,
+    }
+  })
+  .sort((a, b) => a.route.localeCompare(b.route))
+
+const markdown = [
+  '# Super Agents — Complete Documentation Export',
+  '',
+  '> Generated from every canonical documentation page in the Super Agents repository.',
+  '',
+  `- Canonical site: ${siteUrl}`,
+  '- Source: https://github.com/GuillaumeRacine/superagents',
+  `- Registry snapshot: ${registry.asOf}`,
+  `- Pages included: ${pages.length}`,
+  '',
+  'This file is generated. Edit the owning page in `app/`, then run `npm run docs:generate`.',
+  '',
+  ...pages.flatMap((page) => [
+    '---',
+    '',
+    `<!-- source-page: ${page.file} | route: ${page.url} -->`,
+    '',
+    `Source page: [${page.title}](${page.url})`,
+    '',
+    page.content,
+    '',
+  ]),
+].join('\n')
+
+const llms = [
+  '# Super Agents',
+  '',
+  '> A sanitized, evidence-backed map of Gui\'s complete agentic operating environment.',
+  '',
+  '## Complete export',
+  '',
+  `- [Complete Markdown documentation](${siteUrl}/superagents.md): One generated file containing all ${pages.length} canonical pages.`,
+  `- [XML sitemap](${siteUrl}/sitemap.xml): Machine-readable list of canonical website routes.`,
+  '- [GitHub source](https://github.com/GuillaumeRacine/superagents): Versioned source and generation scripts.',
+  '',
+  '## Documentation pages',
+  '',
+  ...pages.map((page) => `- [${page.title}](${page.url})`),
+  '',
+].join('\n')
+
+function writeOrCheck(filename, expected) {
+  const path = join(publicRoot, filename)
+  if (checkOnly) {
+    let current = null
+    try {
+      current = readFileSync(path, 'utf8')
+    } catch {
+      // Report the missing generated file below.
+    }
+    if (current !== expected) {
+      console.error(`${filename} is stale. Run npm run docs:generate.`)
+      process.exitCode = 1
+    }
+    return
+  }
+  mkdirSync(publicRoot, { recursive: true })
+  writeFileSync(path, expected)
+}
+
+writeOrCheck('superagents.md', markdown)
+writeOrCheck('llms.txt', llms)
+
+if (!process.exitCode) {
+  console.log(`${checkOnly ? 'Verified' : 'Generated'} agent exports for ${pages.length} documentation pages.`)
+}

--- a/scripts/smoke-site.mjs
+++ b/scripts/smoke-site.mjs
@@ -99,7 +99,21 @@ try {
 
   assert(sitemap.status === 200 && sitemapLocations.length === expectedPageCount, `Public sitemap must list all ${expectedPageCount} docs pages`)
   assert(sitemapLocations.every((location) => location === canonicalSiteUrl || location.startsWith(`${canonicalSiteUrl}/`)), `Every sitemap URL must use ${canonicalSiteUrl}`)
-  console.log(`Site smoke checks passed: Google provider, exact-email allowlist, auth redirects, RSC, ${legacyRedirects.length} redirects, search, robots, and sitemap.`)
+
+  const markdownExport = await response('/superagents.md')
+  const markdownBody = await markdownExport.text()
+  const exportedPageCount = (markdownBody.match(/<!-- source-page:/g) ?? []).length
+  assert(markdownExport.status === 200, 'Complete Markdown export must be public')
+  assert(markdownExport.headers.get('content-type')?.startsWith('text/markdown'), 'Complete export must use the Markdown content type')
+  assert(markdownExport.headers.get('content-disposition')?.includes('superagents.md'), 'Complete export must download with the canonical filename')
+  assert(exportedPageCount === expectedPageCount, `Complete Markdown export must contain all ${expectedPageCount} docs pages`)
+
+  const llmsIndex = await response('/llms.txt')
+  const llmsBody = await llmsIndex.text()
+  assert(llmsIndex.status === 200, 'llms.txt must be public')
+  assert(llmsBody.includes(`${canonicalSiteUrl}/superagents.md`), 'llms.txt must link the complete Markdown export')
+  assert(llmsBody.includes(`${canonicalSiteUrl}/sitemap.xml`), 'llms.txt must link the XML sitemap')
+  console.log(`Site smoke checks passed: Google provider, exact-email allowlist, auth redirects, RSC, ${legacyRedirects.length} redirects, search, robots, sitemap, and ${exportedPageCount}-page agent export.`)
 } finally {
   if (server.exitCode === null) {
     server.kill('SIGTERM')


### PR DESCRIPTION
## Summary
- publish `/superagents.md` as a downloadable concatenation of every canonical MDX page
- publish `/llms.txt` as an agent discovery index
- add a navigable Agent & Offline Export reference page
- keep both exports public because they mirror the sanitized public repository
- generate and drift-check exports through the existing documentation workflow
- verify export page count, content type, filename, and discovery links in smoke tests

## Current export
- 50 canonical pages
- about 16,500 words
- about 123 KB Markdown

## Verification
- `npm run docs:generate`
- `npm run check`
- `npm run build`
- `npm run smoke`
- documentation audit rerun after changes
- staged and outgoing secret scans clean